### PR TITLE
Port unpaywall to snapshot telescope

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,4 @@ exclude_lines =
 ignore_errors = True
 omit =
     */tests*
+    academic_observatory_workflows/dags/*

--- a/academic_observatory_workflows/fixtures/unpaywall/list_unpaywall_releases.yaml
+++ b/academic_observatory_workflows/fixtures/unpaywall/list_unpaywall_releases.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:983bd6484be545a1b8ffe9c3ccfa01173b66e6ac053661029c47540ecee43f39
-size 4576
+oid sha256:5c4347866d498d4e31d69c5e637bce79f1553df8802f8f2e6bfbee6a50862e50
+size 4533

--- a/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
@@ -30,11 +30,10 @@ from typing import Dict, List, Tuple
 import jsonlines
 import pendulum
 import requests
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.api.common.experimental.pool import create_pool
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.models.variable import Variable
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import (

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -28,17 +28,19 @@ from typing import Dict, List
 
 import pendulum
 import requests
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from bs4 import BeautifulSoup
 from natsort import natsorted
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.url_utils import retry_session
 from observatory.platform.utils.workflow_utils import blob_name, bq_load_shard
-from observatory.platform.workflows.snapshot_telescope import SnapshotRelease, SnapshotTelescope
+from observatory.platform.workflows.snapshot_telescope import (
+    SnapshotRelease,
+    SnapshotTelescope,
+)
 
 
 class CrossrefMetadataRelease(SnapshotRelease):
@@ -58,7 +60,7 @@ class CrossrefMetadataRelease(SnapshotRelease):
 
     @property
     def api_key(self):
-        """ Return API token """
+        """Return API token"""
         connection = BaseHook.get_connection(AirflowConns.CROSSREF)
         return connection.password
 

--- a/academic_observatory_workflows/workflows/geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/geonames_telescope.py
@@ -26,10 +26,9 @@ from zipfile import ZipFile
 
 import pendulum
 import requests
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.data_utils import get_file
 from observatory.platform.workflows.snapshot_telescope import (

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -150,8 +150,7 @@ class TestUnpaywallRelease(unittest.TestCase):
 
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.get_airflow_connection_url")
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.Variable.get")
-    @patch("academic_observatory_workflows.workflows.unpaywall_telescope.wait_for_process")
-    def test_extract_outputs(self, m_wait_for_process, m_variable_get, m_get_conn):
+    def test_extract_outputs(self, m_variable_get, m_get_conn):
         # Create data path and mock getting data path
         data_path = "data"
         m_variable_get.return_value = data_path
@@ -162,20 +161,12 @@ class TestUnpaywallRelease(unittest.TestCase):
                 dag_id="test", release_date=self.unpaywall_test_date, file_name=self.unpaywall_test_file
             )
             shutil.copyfile(self.unpaywall_test_path, release.download_path)
-
-            m_wait_for_process.return_value = ("stdout stuff", None)
-
-            with patch("academic_observatory_workflows.workflows.unpaywall_telescope.logging.info") as m_log:
-                release.extract()
-                self.assertEqual(m_log.call_count, 5)
-
-            m_wait_for_process.return_value = (None, "error")
-            self.assertRaises(AirflowException, release.extract)
+            release.extract()
+            self.assertEqual(len(release.extract_files), 1)
 
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.get_airflow_connection_url")
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.Variable.get")
-    @patch("academic_observatory_workflows.workflows.unpaywall_telescope.wait_for_process")
-    def test_transform_outputs(self, m_wait_for_process, m_variable_get, m_get_conn):
+    def test_transform_outputs(self, m_variable_get, m_get_conn):
         # Create data path and mock getting data path
         data_path = "data"
         m_variable_get.return_value = data_path
@@ -186,18 +177,9 @@ class TestUnpaywallRelease(unittest.TestCase):
                 dag_id="test", release_date=self.unpaywall_test_date, file_name=self.unpaywall_test_file
             )
             shutil.copyfile(self.unpaywall_test_path, release.download_path)
-
-            m_wait_for_process.return_value = (None, None)
             release.extract()
-
-            m_wait_for_process.return_value = ("out", None)
-
-            with patch("academic_observatory_workflows.workflows.unpaywall_telescope.logging.info") as m_log:
-                release.transform()
-                self.assertEqual(m_log.call_count, 4)
-
-            m_wait_for_process.return_value = (None, "error")
-            self.assertRaises(AirflowException, release.transform)
+            release.transform()
+            self.assertEqual(len(release.transform_files), 1)
 
 
 class TestUnpaywallTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -128,7 +128,7 @@ class TestUnpaywallRelease(unittest.TestCase):
 
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.get_airflow_connection_url")
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.Variable.get")
-    @patch("academic_observatory_workflows.workflows.unpaywall_telescope.AsyncHttpFileDownloader.download_file")
+    @patch("academic_observatory_workflows.workflows.unpaywall_telescope.download_file")
     def test_download(self, m_download_files, m_varget, m_get_conn):
         release = UnpaywallRelease(
             dag_id="test", release_date=self.unpaywall_test_date, file_name=self.unpaywall_test_file

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -29,7 +29,7 @@ from observatory.platform.utils.airflow_utils import (
     AirflowVars,
     get_airflow_connection_url,
 )
-from observatory.platform.utils.file_utils import find_replace_file, unzip_files
+from observatory.platform.utils.file_utils import find_replace_file, gunzip_files
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,
     bigquery_table_exists,
@@ -74,6 +74,7 @@ class UnpaywallRelease(SnapshotRelease):
     @property
     def url(self):
         """Download url."""
+
         dataset_url = get_airflow_connection_url(UnpaywallRelease.AIRFLOW_CONNECTION)
         return f"{dataset_url}{self.file_name}"
 
@@ -124,10 +125,11 @@ class UnpaywallRelease(SnapshotRelease):
     def extract(self):
         """Extract release from gzipped file."""
 
-        unzip_files(file_list=[self.download_path], output_dir=self.extract_folder)
+        gunzip_files(file_list=[self.download_path], output_dir=self.extract_folder)
 
     def transform(self):
         """Transforms release by replacing a specific '-' with '_'."""
+
         pattern = "authenticated-orcid"
         replacement = "authenticated_orcid"
         find_replace_file(src=self.extract_path, dst=self.transform_path, pattern=pattern, replacement=replacement)

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -34,13 +34,12 @@ from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,
     bigquery_table_exists,
 )
+from observatory.platform.utils.http_download import download_file
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.url_utils import (
     get_http_response_xml_to_dict,
     get_observatory_http_header,
-    retry_session,
 )
-from observatory.platform.utils.workflow_utils import AsyncHttpFileDownloader
 from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
@@ -128,7 +127,7 @@ class UnpaywallRelease(SnapshotRelease):
         """Download an Unpaywall release.  Either from the snapshot or data freed."""
 
         headers = get_observatory_http_header(package_name="academic_observatory_workflows")
-        AsyncHttpFileDownloader.download_file(url=self.url, filename=self.download_path, headers=headers)
+        download_file(url=self.url, filename=self.download_path, headers=headers)
 
     def extract(self):
         """Extract release from gzipped file."""
@@ -179,7 +178,7 @@ class UnpaywallTelescope(SnapshotTelescope):
         *,
         dag_id: str = DAG_ID,
         start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
-        schedule_interval: str = "@weekly",
+        schedule_interval: str = "@monthly",
         dataset_id: str = "our_research",
         queue: str = "remote_queue",
         schema_folder: str = default_schema_folder(),

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -12,172 +12,110 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Author: Aniek Roelofs
+# Author: Aniek Roelofs, Tuan Chien
 
 import logging
 import os
-import pathlib
 import re
-import shutil
 import subprocess
-from typing import List
+from typing import Dict, List, Union
 
 import pendulum
 import xmltodict
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
 from airflow.models.taskinstance import TaskInstance
-from google.cloud.bigquery import SourceFormat
-
-from academic_observatory_workflows.config import schema_folder
-from observatory.platform.utils.airflow_utils import AirflowVars, check_variables
-from observatory.platform.utils.config_utils import find_schema
-from observatory.platform.utils.data_utils import get_file
+from observatory.platform.utils.airflow_utils import (
+    AirflowVars,
+    get_airflow_connection_url,
+)
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,
     bigquery_table_exists,
-    create_bigquery_dataset,
-    load_bigquery_table,
-    upload_file_to_cloud_storage,
 )
 from observatory.platform.utils.proc_utils import wait_for_process
-from observatory.platform.utils.url_utils import retry_session
-from observatory.platform.utils.workflow_utils import (
-    SubFolder,
-    workflow_path,
+from observatory.platform.utils.url_utils import (
+    get_observatory_http_header,
+    retry_session,
+)
+from observatory.platform.utils.workflow_utils import AsyncHttpFileDownloader
+from observatory.platform.workflows.snapshot_telescope import (
+    SnapshotRelease,
+    SnapshotTelescope,
 )
 
 
-def pull_releases(ti: TaskInstance) -> List:
-    """Pull a list of Unpaywall release instances with xcom.
+class UnpaywallRelease(SnapshotRelease):
+    """Unpaywall Release instance."""
 
-    :param ti: the Apache Airflow task instance.
-    :return: the list of Unpaywall release instances.
-    """
+    AIRFLOW_CONNECTION = "unpaywall_snapshot"
 
-    return ti.xcom_pull(
-        key=UnpaywallTelescope.RELEASES_TOPIC_NAME, task_ids=UnpaywallTelescope.TASK_ID_LIST, include_prior_dates=False
-    )
+    def __init__(
+        self,
+        dag_id: str,
+        release_date: pendulum.DateTime,
+        file_name: str = None,
+    ):
+        """Construct an UnpaywallRelease instance.
 
+        :param dag_id: The DAG ID.
+        :param release_date: Release date.
+        :param file_name: Filename to download.
+        """
 
-def list_releases(start_date: pendulum.DateTime, end_date: pendulum.DateTime) -> List["UnpaywallRelease"]:
-    """Parses xml string retrieved from GET request to create list of urls for
-    different releases.
+        download_files_regex = r".*.jsonl.gz$"
+        transform_files_regex = r".*.jsonl$"
+        extract_files_regex = r".*.jsonl$"
 
-    :param start_date:
-    :param end_date:
-    :return: a list of UnpaywallRelease instances.
-    """
-    releases_list = []
+        super().__init__(
+            dag_id=dag_id,
+            release_date=release_date,
+            download_files_regex=download_files_regex,
+            transform_files_regex=transform_files_regex,
+            extract_files_regex=extract_files_regex,
+        )
 
-    # Request releases page
-    response = retry_session().get(UnpaywallTelescope.TELESCOPE_URL)
-
-    if response is not None and response.status_code == 200:
-        # Parse releases
-        items = xmltodict.parse(response.text)["ListBucketResult"]["Contents"]
-        for item in items:
-            # Get filename and parse dates
-            file_name = item["Key"]
-            last_modified = pendulum.parse(item["LastModified"])
-            release_date = UnpaywallRelease.parse_release_date(file_name)
-
-            # Only include release if last modified date is within start and end date.
-            # Last modified date is used rather than release date because if release date is used then releases will
-            # be missed.
-            if start_date <= last_modified < end_date:
-                release = UnpaywallRelease(file_name, last_modified, release_date)
-                releases_list.append(release)
-    else:
-        raise ConnectionError(f"Error requesting url: {UnpaywallTelescope.TELESCOPE_URL}")
-
-    return releases_list
-
-
-def download_release(release: "UnpaywallRelease") -> str:
-    """Downloads release from url.
-
-    :param release: Instance of UnpaywallRelease class
-    """
-    filename = release.get_filepath_download()
-    download_dir = os.path.dirname(filename)
-
-    # Download
-    logging.info(f"Downloading file: {filename}, url: {release.url}")
-    file_path, updated = get_file(fname=filename, origin=release.url, cache_dir=download_dir)
-
-    if file_path:
-        logging.info(f"Success downloading release: {filename}")
-    else:
-        logging.error(f"Error downloading release: {filename}")
-        exit(os.EX_DATAERR)
-
-    return file_path
-
-
-def extract_release(release: "UnpaywallRelease") -> str:
-    """Decompresses release.
-
-    :param release: Instance of UnpaywallRelease class
-    """
-    logging.info(f"Extracting file: {release.filepath_download}")
-
-    cmd = f"gunzip -c {release.filepath_download} > {release.filepath_extract}"
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable="/bin/bash")
-    stdout, stderr = wait_for_process(p)
-
-    if stdout:
-        logging.info(stdout)
-
-    if stderr:
-        raise AirflowException(f"bash command failed for {release.url}: {stderr}")
-
-    logging.info(f"File extracted to: {release.filepath_extract}")
-
-    return release.filepath_extract
-
-
-def transform_release(release: "UnpaywallRelease") -> str:
-    """Transforms release by replacing a specific '-' with '_'.
-
-    :param release: Instance of UnpaywallRelease class
-    """
-    cmd = (
-        f"sed 's/authenticated-orcid/authenticated_orcid/g' {release.filepath_extract} > "
-        f"{release.filepath_transform}"
-    )
-
-    p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable="/bin/bash")
-    stdout, stderr = wait_for_process(p)
-
-    if stdout:
-        logging.info(stdout)
-
-    if stderr:
-        raise AirflowException(f"bash command failed for {release.url}: {stderr}")
-
-    logging.info(f"Success transforming release: {release.url}")
-
-    return release.filepath_transform
-
-
-class UnpaywallRelease:
-    def __init__(self, file_name: str, last_modified: pendulum.DateTime, release_date: pendulum.DateTime):
         self.file_name = file_name
-        self.last_modified = last_modified
-        self.release_date = release_date
-        self.filepath_download = self.get_filepath_download()
-        self.filepath_extract = self.get_filepath_extract()
-        self.filepath_transform = self.get_filepath_transform()
 
     @property
     def url(self):
-        return f"{UnpaywallTelescope.TELESCOPE_URL}{self.file_name}"
+        """Download url."""
+        dataset_url = get_airflow_connection_url(UnpaywallRelease.AIRFLOW_CONNECTION)
+        return f"{dataset_url}{self.file_name}"
+
+    @property
+    def download_path(self) -> str:
+        """Get the path to the downloaded file.
+
+        :return: the file path.
+        """
+
+        return os.path.join(self.download_folder, "unpaywall.jsonl.gz")
+
+    @property
+    def extract_path(self) -> str:
+        """Get the path to the extracted file.
+
+        :return: the file path.
+        """
+
+        return os.path.join(self.extract_folder, "unpaywall.jsonl")
+
+    @property
+    def transform_path(self) -> str:
+        """Get the path to the transformed file.
+
+        :return: the file path.
+        """
+
+        return os.path.join(self.transform_folder, "unpaywall.jsonl")
 
     @staticmethod
     def parse_release_date(file_name: str) -> pendulum.DateTime:
         """Parses a release date from a file name.
 
+        :param file_name: Unpaywall release file name (contains date string).
         :return: date.
         """
 
@@ -185,90 +123,160 @@ class UnpaywallRelease:
 
         return pendulum.parse(date)
 
-    def get_filepath_download(self) -> str:
-        """Gives path to downloaded release.
+    def download(self):
+        """Download an Unpaywall release.  Either from the snapshot or data freed."""
 
-        :return: absolute file path
-        """
+        headers = get_observatory_http_header(package_name="academic_observatory_workflows")
+        AsyncHttpFileDownloader.download_file(url=self.url, filename=self.download_path, headers=headers)
 
-        date_str = self.release_date.strftime("%Y_%m_%d")
-        compressed_file_name = f"{UnpaywallTelescope.DAG_ID}_{date_str}.jsonl.gz"
-        download_dir = workflow_path(SubFolder.downloaded, UnpaywallTelescope.DAG_ID)
-        path = os.path.join(download_dir, compressed_file_name)
+    def extract(self):
+        """Extract release from gzipped file."""
 
-        return path
+        download_file = self.download_path
+        extract_file = self.extract_path
+        logging.info(f"Extracting file: {download_file}")
 
-    def get_filepath_extract(self) -> str:
-        """Gives path to extracted and decompressed release.
+        cmd = f"gunzip -c {download_file} > {extract_file}"
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable="/bin/bash")
+        stdout, stderr = wait_for_process(p)
 
-        :return: absolute file path
-        """
+        if stdout:
+            logging.info(stdout)
 
-        date_str = self.release_date.strftime("%Y_%m_%d")
-        decompressed_file_name = f"{UnpaywallTelescope.DAG_ID}_{date_str}.jsonl"
-        extract_dir = workflow_path(SubFolder.extracted, UnpaywallTelescope.DAG_ID)
-        path = os.path.join(extract_dir, decompressed_file_name)
+        if stderr:
+            raise AirflowException(f"bash command failed for {self.url}: {stderr}")
 
-        return path
+        logging.info(f"File extracted to: {extract_file}")
 
-    def get_filepath_transform(self) -> str:
-        """Gives path to transformed release.
+    def transform(self):
+        """Transforms release by replacing a specific '-' with '_'."""
 
-        :return: absolute file path
-        """
+        extract_file = self.extract_path
+        transform_file = self.transform_path
 
-        date_str = self.release_date.strftime("%Y_%m_%d")
-        decompressed_file_name = f"{UnpaywallTelescope.DAG_ID}_{date_str}.jsonl"
-        transform_dir = workflow_path(SubFolder.transformed, UnpaywallTelescope.DAG_ID)
-        path = os.path.join(transform_dir, decompressed_file_name)
+        cmd = f"sed 's/authenticated-orcid/authenticated_orcid/g' {extract_file} > " f"{transform_file}"
 
-        return path
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, executable="/bin/bash")
+        stdout, stderr = wait_for_process(p)
+
+        if stdout:
+            logging.info(stdout)
+
+        if stderr:
+            raise AirflowException(f"bash command failed for {self.url}: {stderr}")
+
+        logging.info(f"Success transforming release: {self.url}")
 
 
-class UnpaywallTelescope:
+class UnpaywallTelescope(SnapshotTelescope):
     """A container for holding the constants and static functions for the Unpaywall telescope."""
 
     DAG_ID = "unpaywall"
-    DATASET_ID = "our_research"
-    QUEUE = "remote_queue"
-    DESCRIPTION = "The Unpaywall database: https://unpaywall.org/"
-    RELEASES_TOPIC_NAME = "releases"
-    TELESCOPE_URL = "https://unpaywall-data-snapshots.s3-us-west-2.amazonaws.com/"
-    RETRIES = 3
 
-    TASK_ID_CHECK_DEPENDENCIES = "check_dependencies"
-    TASK_ID_LIST = "list_releases"
-    TASK_ID_STOP = "stop_dag"
-    TASK_ID_DOWNLOAD = "download"
-    TASK_ID_UPLOAD_DOWNLOADED = "upload_downloaded"
-    TASK_ID_EXTRACT = "extract"
-    TASK_ID_TRANSFORM = "transform"
-    TASK_ID_UPLOAD_TRANSFORMED = "upload_transformed"
-    TASK_ID_BQ_LOAD = "bq_load"
-    TASK_ID_CLEANUP = "cleanup"
+    def __init__(
+        self,
+        *,
+        dag_id: str = DAG_ID,
+        start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
+        schedule_interval: str = "@weekly",
+        dataset_id: str = "our_research",
+        queue: str = "remote_queue",
+        schema_folder: str = default_schema_folder(),
+        table_descriptions: Dict = None,
+        catchup: bool = True,
+        airflow_vars: Union[List[AirflowVars], None] = None,
+    ):
+        """Initialise the telescope.
 
-    @staticmethod
-    def check_dependencies(**kwargs):
-        """Check that all variables exist that are required to run the DAG.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
+        :param dag_id: DAG ID.
+        :param start_date: Airflow start date for running the DAG.
+        :param schedule_interval: Airflow schedule interval for running the DAG.
+        :param dataset_id: GCP dataset ID.
+        :param queue: Airflow worker queue to use.
+        :param schema_folder: Folder containing the database schemas.
+        :param table_descriptions: Descriptions of the tables.
+        :param catchup: Whether Airflow should catch up past dag runs.
+        :param airflow_vars: List of Airflow variables to use.
         """
 
-        vars_valid = check_variables(
-            AirflowVars.DATA_PATH,
-            AirflowVars.PROJECT_ID,
-            AirflowVars.DATA_LOCATION,
-            AirflowVars.DOWNLOAD_BUCKET,
-            AirflowVars.TRANSFORM_BUCKET,
+        if table_descriptions is None:
+            table_descriptions = {dag_id: "The Unpaywall database: https://unpaywall.org/"}
+
+        if airflow_vars is None:
+            airflow_vars = [
+                AirflowVars.DATA_PATH,
+                AirflowVars.PROJECT_ID,
+                AirflowVars.DATA_LOCATION,
+                AirflowVars.DOWNLOAD_BUCKET,
+                AirflowVars.TRANSFORM_BUCKET,
+            ]
+
+        airflow_conns = [UnpaywallRelease.AIRFLOW_CONNECTION]
+
+        super().__init__(
+            dag_id,
+            start_date,
+            schedule_interval,
+            dataset_id,
+            schema_folder,
+            table_descriptions=table_descriptions,
+            catchup=catchup,
+            airflow_vars=airflow_vars,
+            airflow_conns=airflow_conns,
+            queue=queue,
         )
-        if not vars_valid:
-            raise AirflowException("Required variables are missing")
+
+        self.add_setup_task(self.check_dependencies)
+        self.add_setup_task(self.get_release_info)
+        self.add_task(self.download)
+        self.add_task(self.upload_downloaded)
+        self.add_task(self.extract)
+        self.add_task(self.transform)
+        self.add_task(self.upload_transformed)
+        self.add_task(self.bq_load)
+        self.add_task(self.cleanup)
 
     @staticmethod
-    def list_releases(**kwargs):
+    def list_releases(start_date: pendulum.DateTime, end_date: pendulum.DateTime) -> List[Dict]:
+        """Parses xml string retrieved from GET request to create list of urls for
+        different releases.
+
+        :param start_date:
+        :param end_date:
+        :return: a list of UnpaywallRelease instances.
+        """
+
+        releases_list = list()
+
+        # Request releases page
+        dataset_url = get_airflow_connection_url(UnpaywallRelease.AIRFLOW_CONNECTION)
+        response = retry_session().get(dataset_url)
+
+        http_ok = 200
+        if response is not None and response.status_code == http_ok:
+            # Parse releases
+            items = xmltodict.parse(response.text)["ListBucketResult"]["Contents"]
+            for item in items:
+                # Get filename and parse dates
+                file_name = item["Key"]
+                last_modified = pendulum.parse(item["LastModified"])
+                release_date = UnpaywallRelease.parse_release_date(file_name)
+
+                # Only include release if last modified date is within start and end date.
+                # Last modified date is used rather than release date because if release date is used then releases will
+                # be missed.
+                if start_date <= last_modified < end_date:
+                    release = {
+                        "date": release_date.format("YYYYMMDD"),
+                        "file_name": file_name,
+                    }
+                    releases_list.append(release)
+        else:
+            raise ConnectionError(f"Error requesting url: {dataset_url}")
+
+        return releases_list
+
+    def get_release_info(self, **kwargs) -> bool:
         """Based on a list of all releases, checks which ones were released between this and the next execution date
         of the DAG. If the release falls within the time period mentioned above, checks if a bigquery table doesn't
         exist yet for the release. A list of releases that passed both checks is passed to the next tasks. If the list
@@ -277,220 +285,80 @@ class UnpaywallTelescope:
         :param kwargs: the context passed from the PythonOperator. See
         https://airflow.apache.org/docs/stable/macros-ref.html
         for a list of the keyword arguments that are passed to this argument.
-        :return: None.
+        :return: Whether the DAG should continue.
         """
 
         # Get variables
         project_id = Variable.get(AirflowVars.PROJECT_ID)
 
         # List releases between a start and end date
-        execution_date = kwargs["execution_date"]
-        next_execution_date = kwargs["next_execution_date"]
-        releases_list = list_releases(execution_date, next_execution_date)
+        execution_date = pendulum.instance(kwargs["execution_date"])
+        next_execution_date = pendulum.instance(kwargs["next_execution_date"])
+        releases_list = UnpaywallTelescope.list_releases(execution_date, next_execution_date)
         logging.info(f"Releases between {execution_date} and {next_execution_date}:\n{releases_list}\n")
 
         # Check if the BigQuery table exists for each release to see if the workflow needs to process
         releases_list_out = []
         for release in releases_list:
-            table_id = bigquery_sharded_table_id(UnpaywallTelescope.DAG_ID, release.release_date)
+            table_id = bigquery_sharded_table_id(UnpaywallTelescope.DAG_ID, pendulum.parse(release["date"]))
 
-            if bigquery_table_exists(project_id, UnpaywallTelescope.DATASET_ID, table_id):
-                logging.info(
-                    f"Skipping as table exists for {release.url}: "
-                    f"{project_id}.{UnpaywallTelescope.DATASET_ID}.{table_id}"
-                )
+            file = release["file_name"]
+            if bigquery_table_exists(project_id, self.dataset_id, table_id):
+                logging.info(f"Skipping as table exists for {file}: " f"{project_id}.{self.dataset_id}.{table_id}")
             else:
-                logging.info(f"Table doesn't exist yet, processing {release.url} in this workflow")
+                logging.info(f"Table doesn't exist yet, processing {file} in this workflow")
                 releases_list_out.append(release)
 
         # If releases_list_out contains items then the DAG will continue (return True) otherwise it will
         # stop (return False)
-        continue_dag = len(releases_list_out)
+        continue_dag = len(releases_list_out) > 0
         if continue_dag:
             ti: TaskInstance = kwargs["ti"]
-            ti.xcom_push(UnpaywallTelescope.RELEASES_TOPIC_NAME, releases_list_out)
+            ti.xcom_push(UnpaywallTelescope.RELEASE_INFO, releases_list_out, execution_date)
         return continue_dag
 
-    @staticmethod
-    def download(**kwargs):
-        """Download release to file.
-        If develop environment, copy debug file from this repository to the right location. Else download from url.
+    def make_release(self, **kwargs) -> List[UnpaywallRelease]:
+        """Make a list of UnpaywallRelease instances.
 
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
+        :param kwargs: The context passed from the PythonOperator.
+        :return: UnpaywallRelease instance.
         """
 
-        # Pull messages
         ti: TaskInstance = kwargs["ti"]
-        releases_list = pull_releases(ti)
-
-        # Download each release
-        for release in releases_list:
-            download_release(release)
-
-    @staticmethod
-    def upload_downloaded(**kwargs):
-        """Upload downloaded release to a google cloud storage bucket.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
-        """
-
-        # Pull messages
-        ti: TaskInstance = kwargs["ti"]
-        releases_list = pull_releases(ti)
-
-        # Get variables
-        bucket_name = Variable.get(AirflowVars.DOWNLOAD_BUCKET)
-
-        # Upload each release
-        for release in releases_list:
-            blob_name = f"telescopes/unpaywall/{os.path.basename(release.filepath_download)}"
-            upload_file_to_cloud_storage(bucket_name, blob_name, file_path=release.filepath_download)
-
-    @staticmethod
-    def extract(**kwargs):
-        """Unzip release to new file.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
-        """
-
-        # Pull messages
-        ti: TaskInstance = kwargs["ti"]
-        releases_list = pull_releases(ti)
-
-        # Extract each release
-        for release in releases_list:
-            extract_release(release)
-
-    @staticmethod
-    def transform(**kwargs):
-        """Transform release with sed command and save to new file.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
-        """
-
-        # Pull messages
-        ti: TaskInstance = kwargs["ti"]
-        releases_list = pull_releases(ti)
-
-        # Transform each release
-        for release in releases_list:
-            transform_release(release)
-
-    @staticmethod
-    def upload_transformed(**kwargs):
-        """Upload transformed release to a google cloud storage bucket.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
-        """
-
-        # Pull messages
-        ti: TaskInstance = kwargs["ti"]
-        releases_list = pull_releases(ti)
-
-        # Get variables
-        bucket_name = Variable.get(AirflowVars.TRANSFORM_BUCKET)
-
-        # Upload each release
-        for release in releases_list:
-            blob_name = f"telescopes/unpaywall/{os.path.basename(release.filepath_transform)}"
-            upload_file_to_cloud_storage(bucket_name, blob_name, file_path=release.filepath_transform)
-
-    @staticmethod
-    def load_to_bq(**kwargs):
-        """Upload transformed release to a bigquery table.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
-        :return: None.
-        """
-
-        # Pull releases
-        ti: TaskInstance = kwargs["ti"]
-        releases_list: List[UnpaywallRelease] = pull_releases(ti)
-
-        # Get variables
-        project_id = Variable.get(AirflowVars.PROJECT_ID)
-        bucket_name = Variable.get(AirflowVars.TRANSFORM_BUCKET)
-        data_location = Variable.get(AirflowVars.DATA_LOCATION)
-
-        # Create dataset
-        create_bigquery_dataset(
-            project_id, UnpaywallTelescope.DATASET_ID, data_location, UnpaywallTelescope.DESCRIPTION
+        release_info = ti.xcom_pull(
+            key=UnpaywallTelescope.RELEASE_INFO,
+            task_ids=self.get_release_info.__name__,
+            include_prior_dates=False,
         )
+        releases = list()
+        for release in release_info:
+            release_date = pendulum.parse(release["date"])
+            file_name = release["file_name"]
+            release = UnpaywallRelease(dag_id=self.dag_id, release_date=release_date, file_name=file_name)
+            releases.append(release)
 
-        for release in releases_list:
-            # Get blob name
-            blob_name = f"telescopes/unpaywall/{os.path.basename(release.filepath_transform)}"
+        return releases
 
-            # Get release_date
-            table_id = bigquery_sharded_table_id(UnpaywallTelescope.DAG_ID, release.release_date)
+    def download(self, releases: List[UnpaywallRelease], **kwargs):
+        """Task to download the Unpaywall"""
 
-            # Select schema file based on release date
-            analysis_schema_path = schema_folder()
-            schema_file_path = find_schema(analysis_schema_path, UnpaywallTelescope.DAG_ID, release.release_date)
-            if schema_file_path is None:
-                logging.error(
-                    f"No schema found with search parameters: analysis_schema_path={analysis_schema_path}, "
-                    f"table_name={UnpaywallTelescope.DAG_ID}, release_date={release.release_date}"
-                )
-                exit(os.EX_CONFIG)
+        for release in releases:
+            release.download()
 
-            # Load BigQuery table
-            uri = f"gs://{bucket_name}/{blob_name}"
-            logging.info(f"URI: {uri}")
-            success = load_bigquery_table(
-                uri,
-                UnpaywallTelescope.DATASET_ID,
-                data_location,
-                table_id,
-                schema_file_path,
-                SourceFormat.NEWLINE_DELIMITED_JSON,
-            )
-            if not success:
-                raise AirflowException("bq_load task: data failed to load data into BigQuery")
+    def extract(self, releases: List[UnpaywallRelease], **kwargs):
+        """Task to extract the releases.
 
-    @staticmethod
-    def cleanup(**kwargs):
-        """Delete files of downloaded, extracted and transformed release.
-
-        :param kwargs: the context passed from the PythonOperator. See
-        https://airflow.apache.org/docs/stable/macros-ref.html
-        for a list of the keyword arguments that are passed to this argument.
+        :param releases: A list of UnpaywallRelease objects.
         :return: None.
         """
+        for release in releases:
+            release.extract()
 
-        # Pull releases
-        ti: TaskInstance = kwargs["ti"]
-        releases_list = pull_releases(ti)
+    def transform(self, releases: List[UnpaywallRelease], **kwargs):
+        """Task to transform the releases.
 
-        for release in releases_list:
-            try:
-                pathlib.Path(release.filepath_download).unlink()
-            except FileNotFoundError as e:
-                logging.warning(f"No such file or directory {release.filepath_download}: {e}")
-
-            try:
-                pathlib.Path(release.filepath_extract).unlink()
-            except FileNotFoundError as e:
-                logging.warning(f"No such file or directory {release.filepath_extract}: {e}")
-
-            try:
-                pathlib.Path(release.filepath_transform).unlink()
-            except FileNotFoundError as e:
-                logging.warning(f"No such file or directory {release.filepath_transform}: {e}")
+        :param releases: A list of UnpaywallRelease objects.
+        :return: None.
+        """
+        for release in releases:
+            release.transform()

--- a/docs/telescopes/unpaywall.md
+++ b/docs/telescopes/unpaywall.md
@@ -13,6 +13,36 @@ hybrid, and bronze."
 ” _- source: [Unpaywall](https://unpaywall.org/)_ 
 and [data details](https://unpaywall.org/data-format)
 
+The Unpaywall snapshot dataset information can be found on the [product page](https://unpaywall.org/products/snapshot).  Users are required to fill in a form to get their download link. The link can be found on the bottom of the [product page](https://unpaywall.org/products/snapshot).
+
+ ```eval_rst
++------------------------------+--------------------------------------+
+| Summary                      |                                      |
++==============================+======================================+
+| Average runtime              |  ?  min                              |
++------------------------------+--------------------------------------+
+| Average download size        |  >16 GB                              |
++------------------------------+--------------------------------------+
+| Harvest Type                 | URL                                  |
++------------------------------+--------------------------------------+
+| Harvest Frequency            | Daily/Weekly/Monthly/Other           |
++------------------------------+--------------------------------------+
+| Runs on remote worker        | True/False                           |
++------------------------------+--------------------------------------+
+| Catchup missed runs          | True/False                           |
++------------------------------+--------------------------------------+
+| Table Write Disposition      | Truncate                             |
++------------------------------+--------------------------------------+
+| Update Frequency             | Daily/Weekly/Monthly/Other           |
++------------------------------+--------------------------------------+
+| Credentials Required         | No                                   |
++------------------------------+--------------------------------------+
+| Uses Workflow Template       | Snapshot                             |
++------------------------------+--------------------------------------+
+| Each shard includes all data | Yes                                  |
++------------------------------+--------------------------------------+
+```
+
 ## Latest schema
 ``` eval_rst
 .. csv-table::

--- a/docs/telescopes/unpaywall.md
+++ b/docs/telescopes/unpaywall.md
@@ -15,25 +15,23 @@ and [data details](https://unpaywall.org/data-format)
 
 The Unpaywall snapshot dataset information can be found on the [product page](https://unpaywall.org/products/snapshot).  Users are required to fill in a form to get their download link. The link can be found on the bottom of the [product page](https://unpaywall.org/products/snapshot).
 
+To give an estimate of dataset size, the 2021-07-02T151134 snapshot is 26 GiB compressed and 177 GiB uncompressed.
+
  ```eval_rst
 +------------------------------+--------------------------------------+
 | Summary                      |                                      |
 +==============================+======================================+
-| Average runtime              |  ?  min                              |
-+------------------------------+--------------------------------------+
-| Average download size        |  >16 GB                              |
-+------------------------------+--------------------------------------+
 | Harvest Type                 | URL                                  |
 +------------------------------+--------------------------------------+
-| Harvest Frequency            | Daily/Weekly/Monthly/Other           |
+| Harvest frequency            | Default: @monthly                    |
 +------------------------------+--------------------------------------+
-| Runs on remote worker        | True/False                           |
+| Runs on remote worker        | Default: True                        |
 +------------------------------+--------------------------------------+
-| Catchup missed runs          | True/False                           |
+| Catchup missed runs          | Default: True                        |
 +------------------------------+--------------------------------------+
 | Table Write Disposition      | Truncate                             |
 +------------------------------+--------------------------------------+
-| Update Frequency             | Daily/Weekly/Monthly/Other           |
+| Dataset Update Frequency     | Roughly 2-6 monthly                  |
 +------------------------------+--------------------------------------+
 | Credentials Required         | No                                   |
 +------------------------------+--------------------------------------+


### PR DESCRIPTION
- Ports Unpaywall to use the snapshot telescope template.
- Make the coverage tool ignore the dags directory.  The dags are tested via dag loading. This is not picked up by the coverage tool so it will always report 0% coverage on dags files.