### PR TITLE
Bugfix deployment

### DIFF
--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -24,9 +24,10 @@ from datetime import timedelta
 from typing import Dict, List, Optional, Tuple
 
 import pendulum
-from academic_observatory_workflows.config import sql_folder
 from airflow.exceptions import AirflowException
 from airflow.models import Variable
+
+from academic_observatory_workflows.config import sql_folder
 from observatory.platform.utils.airflow_utils import AirflowVars, set_task_state
 from observatory.platform.utils.dag_run_sensor import DagRunSensor
 from observatory.platform.utils.gc_utils import (
@@ -41,6 +42,7 @@ from observatory.platform.utils.jinja2_utils import (
     make_sql_jinja2_filename,
     render_template,
 )
+from observatory.platform.utils.workflow_utils import make_release_date
 from observatory.platform.workflows.workflow import Workflow
 
 MAX_QUERIES = 100
@@ -491,7 +493,7 @@ class DoiWorkflow(Workflow):
         :return: A release instance or list of release instances
         """
 
-        release_date = kwargs["next_execution_date"].subtract(microseconds=1).date()
+        release_date = make_release_date(**kwargs)
         project_id = Variable.get(AirflowVars.PROJECT_ID)
         data_location = Variable.get(AirflowVars.DATA_LOCATION)
 

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -221,11 +221,16 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         with self.assertRaises(AirflowException):
             release.extract()
 
-    def test_check_release_exists(self):
+    @patch("academic_observatory_workflows.workflows.crossref_metadata_telescope.BaseHook.get_connection")
+    def test_check_release_exists(self, mock_get_connection):
         """Test the 'check_release_exists' task with different responses.
 
         :return: None.
         """
+
+        # Mock getting Crossref Metadata Connection
+        mock_get_connection.return_value = Connection(password="crossref-token")
+
         release = self.release
         telescope = CrossrefMetadataTelescope()
         with httpretty.enabled():


### PR DESCRIPTION
This PR addresses the following:
* Crossref Metadata now needs the API key to make a head request, so I've added it to the head request.
* Made a standardised `make_release_date` function and use this in Onix Workflow. It returns a pendulum.DateTime rather than a pendulum.Date.
* <s>Fixed a bug in requirements.sh, i.e. removed "RUN" before the echo command </s>: merged here instead https://github.com/The-Academic-Observatory/academic-observatory-workflows/pull/37

The tests will fail until this PR is merged: https://github.com/The-Academic-Observatory/observatory-platform/pull/494