### PR TITLE
Inf 40/create unpaywall data feed telescope

### DIFF
--- a/academic_observatory_workflows/dags/unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_data_feed_telescope.py
@@ -17,9 +17,11 @@
 # The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
 # https://airflow.apache.org/docs/stable/faq.html
 
+import pendulum
 from academic_observatory_workflows.workflows.unpaywall_data_feed_telescope import (
     UnpaywallDataFeedTelescope,
 )
 
-telescope = UnpaywallDataFeedTelescope()
+start_date = pendulum.datetime(2021, 7, 2)  # Set this to the snapshot release date you want to base it off
+telescope = UnpaywallDataFeedTelescope(start_date=start_date)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_data_feed_telescope.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Tuan Chien
+
+# The keywords airflow and DAG are required to load the DAGs from this file, see bullet 2 in the Apache Airflow FAQ:
+# https://airflow.apache.org/docs/stable/faq.html
+
+from academic_observatory_workflows.workflows.unpaywall_data_feed_telescope import (
+    UnpaywallDataFeedTelescope,
+)
+
+telescope = UnpaywallDataFeedTelescope()
+globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/database/schema/unpaywall_data_feed_2021-02-18.json
+++ b/academic_observatory_workflows/database/schema/unpaywall_data_feed_2021-02-18.json
@@ -1,0 +1,540 @@
+[
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "evidence",
+        "type": "STRING",
+        "description": "How we found this OA location. Used for debugging. Don’t depend on the exact contents of this for anything, because values are subject to change without warning."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "host_type",
+        "type": "STRING",
+        "description": "The type of host that serves this OA location. There are two possible values: 'publisher' means this location is served by the article’s publisher (in practice, this usually means it is hosted on the same domain the DOI resolves to). 'repository' means this location is served by an Open Access repository. Preprint servers are considered repositories even if the DOI resolves there."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "is_best",
+        "type": "BOOLEAN",
+        "description": "Is this location the best_oa_location for its resource. See the DOI object's best_oa_location description for more on how we select which location is \"best.\""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "license",
+        "type": "STRING",
+        "description": "The license under which this copy is published. We return several types of licenses: Creative Commons licenses are uniformly abbreviated and lowercased. Example: 'cc-by-nc'. Publisher-specific licenses are normalized using this format: 'acs-specific: authorchoice/editors choice usage agreement'. When we have evidence that an OA license of some kind was used, but it’s not reported directly on the webpage at this location, this field returns 'implied-oa'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "oa_date",
+        "type": "DATE",
+        "description": "When this document first became available at this location. oa_date is calculated differently for different host types and is not available for all oa_locations. See https://support.unpaywall.org/a/solutions/articles/44002063719 for details."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "pmh_id",
+        "type": "STRING",
+        "description": "OAI-PMH endpoint where we found this location. This is primarily for internal debugging. It's null for locations that weren't found using OAI-PMH."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "TIMESTAMP",
+        "description": "Time when the data for this location was last updated. Returned as an ISO8601-formatted timestamp. Example: 2017-08-17T23:43:27.753663"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING",
+        "description": "The url_for_pdf if there is one; otherwise landing page URL. When we can't find a url_for_pdf (or there isn't one), this field uses the url_for_landing_page, which is a useful fallback for some use cases."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_landing_page",
+        "type": "STRING",
+        "description": "The URL for a landing page describing this OA copy. When the host_type is \"publisher\" the landing page usually includes HTML fulltext."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_pdf",
+        "type": "STRING",
+        "description": "The URL with a PDF version of this OA copy."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "version",
+        "type": "STRING",
+        "description": "The content version accessible at this location. We use the DRIVER Guidelines v2.0 VERSION standard (https://wiki.surfnet.nl/display/DRIVERguidelines/DRIVER-VERSION+Mappings) to define versions of a given article; see those docs for complete definitions of terms."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "repository_institution",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "endpoint_id",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "id",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "best_oa_location",
+    "type": "RECORD",
+    "description": "The best OA Location Object we could find for this DOI. The \"best\" location is determined using an algorithm that prioritizes publisher-hosted content first (eg Hybrid or Gold), then prioritizes versions closer to the version of record (PublishedVersion over AcceptedVersion), then more authoritative repositories (PubMed Central over CiteSeerX). Returns null if we couldn't find any OA Locations."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "data_standard",
+    "type": "INTEGER",
+    "description": "Indicates the data collection approaches used for this resource. Possible values: '1' First-generation hybrid detection. Uses only data from the Crossref API to determine hybrid status. Does a good job for Elsevier articles and a few other publishers, but most publishers are not checked for hybrid. '2' Second-generation hybrid detection. Uses additional sources, checks all publishers for hybrid. Gets about 10x as much hybrid. data_standard==2 is the version used in the paper we wrote about the dataset."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "doi",
+    "type": "STRING",
+    "description": "The DOI of this resource. This is always lowercase."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "doi_url",
+    "type": "STRING",
+    "description": "The DOI in hyperlink form. This field simply contains \"https://doi.org/\" prepended to the doi field. It expresses the DOI in its correct format according to the Crossref DOI display guidelines."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "genre",
+    "type": "STRING",
+    "description": "The type of resource. Currently the genre is identical to the Crossref-reported type of a given resource. The \"journal-article\" type is most common, but there are many others."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_paratext",
+    "type": "BOOLEAN",
+    "description": "Is the item an ancillary part of a journal, like a table of contents? See here for more information on how we determine whether an article is paratext: https://support.unpaywall.org/support/solutions/articles/44001894783."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "is_oa",
+    "type": "BOOLEAN",
+    "description": "Is there an OA copy of this resource. Convenience attribute; returns true when best_oa_location is not null."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "journal_is_in_doaj",
+    "type": "BOOLEAN",
+    "description": "Is this resource published in a DOAJ-indexed journal. Useful for defining whether a resource is Gold OA (depending on your definition, see also journal_is_oa)."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "journal_is_oa",
+    "type": "BOOLEAN",
+    "description": "Is this resource published in a completely OA journal.\tUseful for defining whether a resource is Gold OA. Includes any fully-OA journal, regardless of inclusion in DOAJ. This includes journals by all-OA publishers and journals that would otherwise be all Hybrid or Bronze OA."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "journal_issns",
+    "type": "STRING",
+    "description": "Any ISSNs assigned to the journal publishing this resource. Separate ISSNs are sometimes assigned to print and electronic versions of the same journal. If there are multiple ISSNs, they are separated by commas. Example: 1232-1203,1532-6203"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "journal_issn_l",
+    "type": "STRING",
+    "description": "A single ISSN for the journal publishing this resource. An ISSN-L can be used as a primary key for a journal when more than one ISSN is assigned to it. Resources' journal_issns are mapped to ISSN-Ls using the issn.org table, with some manual corrections."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "journal_name",
+    "type": "STRING",
+    "description": "The name of the journal publishing this resource. The same journal may have multiple name strings (eg, \"J. Foo\", \"Journal of Foo\", \"JOURNAL OF FOO\", etc). These have not been fully normalized within our database, so use with care."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "evidence",
+        "type": "STRING",
+        "description": "How we found this OA location. Used for debugging. Don’t depend on the exact contents of this for anything, because values are subject to change without warning."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "host_type",
+        "type": "STRING",
+        "description": "The type of host that serves this OA location. There are two possible values: 'publisher' means this location is served by the article’s publisher (in practice, this usually means it is hosted on the same domain the DOI resolves to). 'repository' means this location is served by an Open Access repository. Preprint servers are considered repositories even if the DOI resolves there."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "is_best",
+        "type": "BOOLEAN",
+        "description": "Is this location the best_oa_location for its resource. See the DOI object's best_oa_location description for more on how we select which location is \"best.\""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "license",
+        "type": "STRING",
+        "description": "The license under which this copy is published. We return several types of licenses: Creative Commons licenses are uniformly abbreviated and lowercased. Example: 'cc-by-nc'. Publisher-specific licenses are normalized using this format: 'acs-specific: authorchoice/editors choice usage agreement'. When we have evidence that an OA license of some kind was used, but it’s not reported directly on the webpage at this location, this field returns 'implied-oa'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "oa_date",
+        "type": "DATE",
+        "description": "When this document first became available at this location. oa_date is calculated differently for different host types and is not available for all oa_locations. See https://support.unpaywall.org/a/solutions/articles/44002063719 for details."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "pmh_id",
+        "type": "STRING",
+        "description": "OAI-PMH endpoint where we found this location. This is primarily for internal debugging. It's null for locations that weren't found using OAI-PMH."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "TIMESTAMP",
+        "description": "Time when the data for this location was last updated. Returned as an ISO8601-formatted timestamp. Example: 2017-08-17T23:43:27.753663"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING",
+        "description": "The url_for_pdf if there is one; otherwise landing page URL. When we can't find a url_for_pdf (or there isn't one), this field uses the url_for_landing_page, which is a useful fallback for some use cases."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_landing_page",
+        "type": "STRING",
+        "description": "The URL for a landing page describing this OA copy. When the host_type is \"publisher\" the landing page usually includes HTML fulltext."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_pdf",
+        "type": "STRING",
+        "description": "The URL with a PDF version of this OA copy."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "version",
+        "type": "STRING",
+        "description": "The content version accessible at this location. We use the DRIVER Guidelines v2.0 VERSION standard (https://wiki.surfnet.nl/display/DRIVERguidelines/DRIVER-VERSION+Mappings) to define versions of a given article; see those docs for complete definitions of terms."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "repository_institution",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "endpoint_id",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "id",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "oa_locations",
+    "type": "RECORD",
+    "description": "List of all the OA Location objects associated with this resource. This list is unnecessary for the vast majority of use-cases, since you probably just want the best_oa_location. It's included primarily for research purposes."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "evidence",
+        "type": "STRING",
+        "description": "How we found this OA location. Used for debugging. Don’t depend on the exact contents of this for anything, because values are subject to change without warning."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "host_type",
+        "type": "STRING",
+        "description": "The type of host that serves this OA location. There are two possible values: 'publisher' means this location is served by the article’s publisher (in practice, this usually means it is hosted on the same domain the DOI resolves to). 'repository' means this location is served by an Open Access repository. Preprint servers are considered repositories even if the DOI resolves there."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "is_best",
+        "type": "BOOLEAN",
+        "description": "Is this location the best_oa_location for its resource. See the DOI object's best_oa_location description for more on how we select which location is \"best.\""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "license",
+        "type": "STRING",
+        "description": "The license under which this copy is published. We return several types of licenses: Creative Commons licenses are uniformly abbreviated and lowercased. Example: 'cc-by-nc'. Publisher-specific licenses are normalized using this format: 'acs-specific: authorchoice/editors choice usage agreement'. When we have evidence that an OA license of some kind was used, but it’s not reported directly on the webpage at this location, this field returns 'implied-oa'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "oa_date",
+        "type": "DATE",
+        "description": "When this document first became available at this location. oa_date is calculated differently for different host types and is not available for all oa_locations. See https://support.unpaywall.org/a/solutions/articles/44002063719 for details."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "pmh_id",
+        "type": "STRING",
+        "description": "OAI-PMH endpoint where we found this location. This is primarily for internal debugging. It's null for locations that weren't found using OAI-PMH."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "TIMESTAMP",
+        "description": "Time when the data for this location was last updated. Returned as an ISO8601-formatted timestamp. Example: 2017-08-17T23:43:27.753663"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING",
+        "description": "The url_for_pdf if there is one; otherwise landing page URL. When we can't find a url_for_pdf (or there isn't one), this field uses the url_for_landing_page, which is a useful fallback for some use cases."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_landing_page",
+        "type": "STRING",
+        "description": "The URL for a landing page describing this OA copy. When the host_type is \"publisher\" the landing page usually includes HTML fulltext."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_pdf",
+        "type": "STRING",
+        "description": "The URL with a PDF version of this OA copy."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "version",
+        "type": "STRING",
+        "description": "The content version accessible at this location. We use the DRIVER Guidelines v2.0 VERSION standard (https://wiki.surfnet.nl/display/DRIVERguidelines/DRIVER-VERSION+Mappings) to define versions of a given article; see those docs for complete definitions of terms."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "repository_institution",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "endpoint_id",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "id",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "first_oa_location",
+    "type": "RECORD",
+    "description": "The OA Location Object with the earliest oa_date. Returns null if we couldn't find any OA Locations."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "oa_status",
+    "type": "STRING",
+    "description": "The OA status, or color, of this resource. Classifies OA resources by location and license terms as one of: gold, hybrid, bronze, green or closed. See here for more information on how we assign an oa_status: https://support.unpaywall.org/support/solutions/articles/44001777288-what-do-the-types-of-oa-status-green-gold-hybrid-and-bronze-mean-"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "published_date",
+    "type": "DATE",
+    "description": "The date this resource was published. As reported by the publishers, who unfortunately have inconsistent definitions of what counts as officially \"published.\" Returned as an ISO8601-formatted timestamp, generally with only year-month-day."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "publisher",
+    "type": "STRING",
+    "description": "The name of this resource's publisher. Keep in mind that publisher name strings change over time, particularly as publishers are acquired or split up."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "title",
+    "type": "STRING",
+    "description": "The title of this resource."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "updated",
+    "type": "TIMESTAMP",
+    "description": "Time when the data for this resource was last updated. Returned as an ISO8601-formatted timestamp. Example: 2017-08-17T23:43:27.753663"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "year",
+    "type": "INTEGER",
+    "description": "The year this resource was published. Just the year part of the published_date"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "sequence",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "z_authors",
+    "type": "RECORD",
+    "description": "The authors of this resource. These are formatted as a list of Crossref Contributor objects, which are described in the Crossref API docs here: https://github.com/CrossRef/rest-api-doc/blob/master/api_format.md#contributor"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "has_repository_copy",
+    "type": "BOOLEAN",
+    "description": "Is a full-text available in a repository?"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "issn_l",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "blank",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "x_reported_noncompliant_copies",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "x_error",
+    "type": "BOOLEAN"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "evidence",
+        "type": "STRING",
+        "description": "How we found this OA location. Used for debugging. Don’t depend on the exact contents of this for anything, because values are subject to change without warning."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "host_type",
+        "type": "STRING",
+        "description": "The type of host that serves this OA location. There are two possible values: 'publisher' means this location is served by the article’s publisher (in practice, this usually means it is hosted on the same domain the DOI resolves to). 'repository' means this location is served by an Open Access repository. Preprint servers are considered repositories even if the DOI resolves there."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "is_best",
+        "type": "BOOLEAN",
+        "description": "Is this location the best_oa_location for its resource. See the DOI object's best_oa_location description for more on how we select which location is \"best.\""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "license",
+        "type": "STRING",
+        "description": "The license under which this copy is published. We return several types of licenses: Creative Commons licenses are uniformly abbreviated and lowercased. Example: 'cc-by-nc'. Publisher-specific licenses are normalized using this format: 'acs-specific: authorchoice/editors choice usage agreement'. When we have evidence that an OA license of some kind was used, but it’s not reported directly on the webpage at this location, this field returns 'implied-oa'"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "oa_date",
+        "type": "DATE",
+        "description": "When this document first became available at this location. oa_date is calculated differently for different host types and is not available for all oa_locations. See https://support.unpaywall.org/a/solutions/articles/44002063719 for details."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "pmh_id",
+        "type": "STRING",
+        "description": "OAI-PMH endpoint where we found this location. This is primarily for internal debugging. It's null for locations that weren't found using OAI-PMH."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "TIMESTAMP",
+        "description": "Time when the data for this location was last updated. Returned as an ISO8601-formatted timestamp. Example: 2017-08-17T23:43:27.753663"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url",
+        "type": "STRING",
+        "description": "The url_for_pdf if there is one; otherwise landing page URL. When we can't find a url_for_pdf (or there isn't one), this field uses the url_for_landing_page, which is a useful fallback for some use cases."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_landing_page",
+        "type": "STRING",
+        "description": "The URL for a landing page describing this OA copy. When the host_type is \"publisher\" the landing page usually includes HTML fulltext."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "url_for_pdf",
+        "type": "STRING",
+        "description": "The URL with a PDF version of this OA copy."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "version",
+        "type": "STRING",
+        "description": "The content version accessible at this location. We use the DRIVER Guidelines v2.0 VERSION standard (https://wiki.surfnet.nl/display/DRIVERguidelines/DRIVER-VERSION+Mappings) to define versions of a given article; see those docs for complete definitions of terms."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "repository_institution",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "endpoint_id",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "oa_locations_embargoed",
+    "type": "RECORD",
+    "description": "List of OA Location objects associated with this resource that are not yet available. This list includes locations that we expect to be available in the future based on information like license metadata and journals' delayed OA policies. They do not affect the resource's oa_status and cannot be the best_oa_location or first_oa_location."
+  }
+]

--- a/academic_observatory_workflows/database/schema/unpaywall_data_feed_2021-02-18.json
+++ b/academic_observatory_workflows/database/schema/unpaywall_data_feed_2021-02-18.json
@@ -95,7 +95,7 @@
     "description": "Indicates the data collection approaches used for this resource. Possible values: '1' First-generation hybrid detection. Uses only data from the Crossref API to determine hybrid status. Does a good job for Elsevier articles and a few other publishers, but most publishers are not checked for hybrid. '2' Second-generation hybrid detection. Uses additional sources, checks all publishers for hybrid. Gets about 10x as much hybrid. data_standard==2 is the version used in the paper we wrote about the dataset."
   },
   {
-    "mode": "NULLABLE",
+    "mode": "REQUIRED",
     "name": "doi",
     "type": "STRING",
     "description": "The DOI of this resource. This is always lowercase."

--- a/academic_observatory_workflows/fixtures/unpaywall_data_feed/daily-feed/changefile/changed_dois_with_versions_2021-07-02T080001.jsonl.gz
+++ b/academic_observatory_workflows/fixtures/unpaywall_data_feed/daily-feed/changefile/changed_dois_with_versions_2021-07-02T080001.jsonl.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8e662a8e9de255abed1c9459f1a6f3e735a6a34fc1f1463554defc8f9d3e476
+size 1295

--- a/academic_observatory_workflows/fixtures/unpaywall_data_feed/daily-feed/changefiles.jinja2
+++ b/academic_observatory_workflows/fixtures/unpaywall_data_feed/daily-feed/changefiles.jinja2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60fd519b80f3fd36f4b3b74f8ae790680d2576c3ad2b586691984c26811bafed
+size 441

--- a/academic_observatory_workflows/fixtures/unpaywall_data_feed/unpaywall_snapshot_2021-07-02T151134.jsonl.gz
+++ b/academic_observatory_workflows/fixtures/unpaywall_data_feed/unpaywall_snapshot_2021-07-02T151134.jsonl.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75246a7865c91ba82614bfa178e94e69db5e452f5887dfcfccfaddb089ddae8b
+size 16559

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_data_feed_telescope.py
@@ -249,7 +249,7 @@ class TestUnpaywallDataFeedTelescope(ObservatoryTestCase):
     def test_schedule_days_apart(self):
         start_date = pendulum.datetime(2021, 1, 9)
         schedule_interval = timedelta(days=2)
-        days_apart_gen = UnpaywallDataFeedTelescope.schedule_days_apart_(
+        days_apart_gen = UnpaywallDataFeedTelescope._schedule_days_apart(
             start_date=start_date, schedule_interval=schedule_interval
         )
 
@@ -259,7 +259,7 @@ class TestUnpaywallDataFeedTelescope(ObservatoryTestCase):
         self.assertEqual(diff, 2)
 
         schedule_interval = "@weekly"
-        days_apart_gen = UnpaywallDataFeedTelescope.schedule_days_apart_(
+        days_apart_gen = UnpaywallDataFeedTelescope._schedule_days_apart(
             start_date=start_date, schedule_interval=schedule_interval
         )
 

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_data_feed_telescope.py
@@ -1,0 +1,406 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Tuan Chien
+
+import os
+import shutil
+import unittest
+from unittest.mock import patch
+
+import pendulum
+from academic_observatory_workflows.config import test_fixtures_folder
+from academic_observatory_workflows.workflows.unpaywall_data_feed_telescope import (
+    UnpaywallDataFeedRelease,
+    UnpaywallDataFeedTelescope,
+)
+from airflow.exceptions import AirflowException
+from airflow.models.connection import Connection
+from airflow.utils.state import State
+from click.testing import CliRunner
+from observatory.platform.utils.file_utils import validate_file_hash
+from observatory.platform.utils.test_utils import (
+    HttpServer,
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    module_file_path,
+)
+from observatory.platform.utils.workflow_utils import (
+    bigquery_sharded_table_id,
+    blob_name,
+)
+
+
+class TestUnpaywallDataFeedRelease(unittest.TestCase):
+    def test_ctor(self):
+        # OK
+        release = UnpaywallDataFeedRelease(
+            dag_id="dag",
+            start_date=pendulum.now(),
+            end_date=pendulum.now(),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="day",
+        )
+
+        # Invalid update interval
+        self.assertRaises(
+            AirflowException,
+            UnpaywallDataFeedRelease,
+            dag_id="dag",
+            start_date=pendulum.now(),
+            end_date=pendulum.now(),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="invalid",
+        )
+
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.get_airflow_connection_password")
+    def test_api_key(self, m_pass):
+        m_pass.return_value = "testpass"
+        release = UnpaywallDataFeedRelease(
+            dag_id="dag",
+            start_date=pendulum.now(),
+            end_date=pendulum.now(),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="day",
+        )
+        self.assertEqual(release.api_key, "testpass")
+
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.get_airflow_connection_password")
+    def test_snapshot_url(self, m_pass):
+        m_pass.return_value = "testpass"
+        release = UnpaywallDataFeedRelease(
+            dag_id="dag",
+            start_date=pendulum.now(),
+            end_date=pendulum.now(),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="day",
+        )
+        url = "https://api.unpaywall.org/feed/snapshot?api_key=testpass"
+        self.assertEqual(release.snapshot_url, url)
+
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.get_airflow_connection_password")
+    def test_data_feed_url(self, m_pass):
+        m_pass.return_value = "testpass"
+        release = UnpaywallDataFeedRelease(
+            dag_id="dag",
+            start_date=pendulum.now(),
+            end_date=pendulum.now(),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="day",
+        )
+        url = "https://api.unpaywall.org/feed/changefiles?interval=day&api_key=testpass"
+        self.assertEqual(release.data_feed_url, url)
+
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.get_airflow_connection_password")
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.download_files")
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.get_observatory_http_header")
+    @patch("academic_observatory_workflows.workflows.unpaywall_data_feed_telescope.get_http_response_json")
+    @patch("airflow.models.variable.Variable.get")
+    def test_download_data_feed(self, m_get, m_get_response, m_header, m_download, m_pass):
+        m_get.return_value = "data"
+        m_pass.return_value = "testpass"
+        m_header.return_value = {"User-Agent": "custom"}
+
+        # Day
+        m_get_response.return_value = [
+            {"date": "2021-01-01", "url": "http://url1", "filename": "file1"},
+            {"date": "2020-01-01", "url": "http://url2", "filename": "file2"},
+        ]
+
+        release = UnpaywallDataFeedRelease(
+            dag_id="dag",
+            start_date=pendulum.datetime(2021, 1, 1),
+            end_date=pendulum.datetime(2021, 1, 3),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="day",
+        )
+
+        release.download_data_feed_()
+        _, call_args = m_download.call_args
+        download_list = call_args["download_list"]
+        self.assertEqual(len(download_list), 1)
+        self.assertEqual(download_list[0]["url"], "http://url1")
+        self.assertEqual(download_list[0]["filename"], "data/telescopes/download/dag/2021_01_01-2021_01_03/file1")
+
+        # Week
+        m_get_response.return_value = [
+            {"to_date": "2021-01-01", "url": "http://url1", "filename": "file1"},
+            {"to_date": "2020-01-01", "url": "http://url2", "filename": "file2"},
+        ]
+
+        release = UnpaywallDataFeedRelease(
+            dag_id="dag",
+            start_date=pendulum.datetime(2021, 1, 1),
+            end_date=pendulum.datetime(2021, 1, 3),
+            first_release=True,
+            max_download_connections=1,
+            update_interval="week",
+        )
+
+        release.download_data_feed_()
+        _, call_args = m_download.call_args
+        download_list = call_args["download_list"]
+        self.assertEqual(len(download_list), 1)
+        self.assertEqual(download_list[0]["url"], "http://url1")
+        self.assertEqual(download_list[0]["filename"], "data/telescopes/download/dag/2021_01_01-2021_01_03/file1")
+
+    def test_download_snapshot(self):
+        pass
+
+    @patch("airflow.models.variable.Variable.get")
+    def test_extract(self, m_get):
+        m_get.return_value = "data"
+        fixture_dir = test_fixtures_folder("unpaywall_data_feed")
+        with CliRunner().isolated_filesystem():
+            release = UnpaywallDataFeedRelease(
+                dag_id="dag",
+                start_date=pendulum.datetime(2021, 1, 1),
+                end_date=pendulum.datetime(2021, 1, 3),
+                first_release=True,
+                max_download_connections=1,
+                update_interval="week",
+            )
+            src = os.path.join(fixture_dir, "unpaywall.jsonl.gz")
+            dst = os.path.join(release.download_folder, "unpaywall.jsonl.gz")
+            shutil.copyfile(src, dst)
+            self.assertEqual(len(release.download_files), 1)
+            release.extract()
+            self.assertEqual(len(release.extract_files), 1)
+
+    @patch("airflow.models.variable.Variable.get")
+    def test_transform(self, m_get):
+        m_get.return_value = "data"
+        fixture_dir = test_fixtures_folder("unpaywall_data_feed")
+        with CliRunner().isolated_filesystem():
+            release = UnpaywallDataFeedRelease(
+                dag_id="dag",
+                start_date=pendulum.datetime(2021, 1, 1),
+                end_date=pendulum.datetime(2021, 1, 3),
+                first_release=True,
+                max_download_connections=1,
+                update_interval="week",
+            )
+            src = os.path.join(fixture_dir, "unpaywall.jsonl.gz")
+            dst = os.path.join(release.download_folder, "unpaywall.jsonl.gz")
+            shutil.copyfile(src, dst)
+            src = os.path.join(fixture_dir, "unpaywall1.csv.gz")
+            dst = os.path.join(release.download_folder, "unpaywall1.csv.gz")
+            shutil.copyfile(src, dst)
+            release.extract()
+            release.transform()
+            self.assertEqual(len(release.transform_files), 2)
+
+            csv_transformed_hash = "5ec6414a16ce7af18855c146534f80c7"
+            json_transformed_hash = "62cbb5af5a78d2e0769a28d976971cba"
+
+            json_transformed = os.path.join(release.transform_folder, "unpaywall.jsonl")
+            csv_transformed = os.path.join(release.transform_folder, "unpaywall1.csv.jsonl")
+            self.assertTrue(validate_file_hash(file_path=csv_transformed, expected_hash=csv_transformed_hash))
+            self.assertTrue(validate_file_hash(file_path=json_transformed, expected_hash=json_transformed_hash))
+
+
+class TestUnpaywallDataFeedTelescope(ObservatoryTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
+        self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
+        self.first_execution_date = pendulum.datetime(2021, 7, 18)
+        self.second_execution_date = pendulum.datetime(2021, 2, 19)
+        self.fixture_dir = test_fixtures_folder("unpaywall_data_feed")
+
+    def test_ctor(self):
+        telescope = UnpaywallDataFeedTelescope(airflow_vars=[])
+        self.assertEqual(telescope.airflow_vars, ["transform_bucket"])
+
+    def test_dag_structure(self):
+        """Test that the Crossref Events DAG has the correct structure."""
+
+        dag = UnpaywallDataFeedTelescope().make_dag()
+        self.assert_dag_structure(
+            {
+                "check_dependencies": ["get_release_info"],
+                "get_release_info": ["download"],
+                "download": ["upload_downloaded"],
+                "upload_downloaded": ["extract"],
+                "extract": ["transform"],
+                "transform": ["upload_transformed"],
+                "upload_transformed": ["bq_load_partition"],
+                "bq_load_partition": ["bq_delete_old"],
+                "bq_delete_old": ["bq_append_new"],
+                "bq_append_new": ["cleanup"],
+                "cleanup": [],
+            },
+            dag,
+        )
+
+    def test_dag_load(self):
+        """Test that the DAG can be loaded from a DAG bag."""
+
+        with ObservatoryEnvironment().create():
+            dag_file = os.path.join(
+                module_file_path("academic_observatory_workflows.dags"), "unpaywall_data_feed_telescope.py"
+            )
+            self.assert_dag_load("unpaywall_data_feed", dag_file)
+
+    def setup_observatory_environment(self):
+        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        self.dataset_id = env.add_dataset()
+        return env
+
+    def test_telescope(self):
+        env = self.setup_observatory_environment()
+
+        with env.create():
+            server = HttpServer(directory=self.fixture_dir)
+            with server.create():
+                with patch.object(
+                    UnpaywallDataFeedRelease, "SNAPSHOT_URL", f"http://{server.host}:{server.port}/feed/snapshot.json"
+                ):
+                    conn = Connection(
+                        conn_id=UnpaywallDataFeedRelease.AIRFLOW_CONNECTION, uri="http://:YOUR_API_KEY@localhost"
+                    )
+
+                    env.add_connection(conn)
+
+                    telescope = UnpaywallDataFeedTelescope(dataset_id=self.dataset_id)
+                    dag = telescope.make_dag()
+
+                    # First run
+                    with env.create_dag_run(dag, self.first_execution_date):
+                        release = UnpaywallDataFeedRelease(
+                            dag_id=UnpaywallDataFeedTelescope.DAG_ID,
+                            start_date=pendulum.datetime(2021, 7, 2),
+                            end_date=pendulum.datetime(2021, 7, 18),
+                            first_release=True,
+                            max_download_connections=1,
+                            update_interval="day",
+                        )
+
+                        # Check dependencies are met
+                        ti = env.run_task(telescope.check_dependencies.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Get release information
+                        ti = env.run_task(telescope.get_release_info.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Download data
+                        ti = env.run_task(telescope.download.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Upload downloaded data
+                        ti = env.run_task(telescope.upload_downloaded.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Extract data
+                        ti = env.run_task(telescope.extract.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Transform data
+                        ti = env.run_task(telescope.transform.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Upload transformed data
+                        ti = env.run_task(telescope.upload_transformed.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Load bq table partitions
+                        ti = env.run_task(telescope.bq_load_partition.__name__)
+                        self.assertEqual(ti.state, State.SKIPPED)
+
+                        # Delete changed data from main table
+                        ti = env.run_task(telescope.bq_delete_old.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Add new changes
+                        ti = env.run_task(telescope.bq_append_new.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Cleanup files
+                        download_folder, extract_folder, transform_folder = (
+                            release.download_folder,
+                            release.extract_folder,
+                            release.transform_folder,
+                        )
+                        ti = env.run_task(telescope.cleanup.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+                        self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                    # # Second run
+                    with env.create_dag_run(dag, self.second_execution_date):
+                        release = UnpaywallDataFeedRelease(
+                            dag_id=UnpaywallDataFeedTelescope.DAG_ID,
+                            start_date=pendulum.datetime(2021, 7, 19),
+                            end_date=pendulum.datetime(2021, 7, 19),
+                            first_release=False,
+                            max_download_connections=1,
+                            update_interval="day",
+                        )
+
+                        # Check dependencies are met
+                        ti = env.run_task(telescope.check_dependencies.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Get release information
+                        ti = env.run_task(telescope.get_release_info.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Download data
+                        ti = env.run_task(telescope.download.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Upload downloaded data
+                        ti = env.run_task(telescope.upload_downloaded.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Extract data
+                        ti = env.run_task(telescope.extract.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Transform data
+                        ti = env.run_task(telescope.transform.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Upload transformed data
+                        ti = env.run_task(telescope.upload_transformed.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Load bq table partitions
+                        ti = env.run_task(telescope.bq_load_partition.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Delete changed data from main table
+                        ti = env.run_task(telescope.bq_delete_old.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Add new changes
+                        ti = env.run_task(telescope.bq_append_new.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+
+                        # Cleanup files
+                        download_folder, extract_folder, transform_folder = (
+                            release.download_folder,
+                            release.extract_folder,
+                            release.transform_folder,
+                        )
+                        ti = env.run_task(telescope.cleanup.__name__)
+                        self.assertEqual(ti.state, State.SUCCESS)
+                        self.assert_cleanup(download_folder, extract_folder, transform_folder)

--- a/academic_observatory_workflows/workflows/unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_data_feed_telescope.py
@@ -36,6 +36,7 @@ from observatory.platform.utils.url_utils import (
     get_http_response_json,
     get_observatory_http_header,
 )
+from observatory.platform.utils.workflow_utils import is_first_dag_run
 from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,

--- a/academic_observatory_workflows/workflows/unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_data_feed_telescope.py
@@ -42,11 +42,6 @@ from observatory.platform.workflows.stream_telescope import (
 )
 
 
-# Replace after other PR merged
-def is_first_dag_run(**kwargs) -> bool:
-    return kwargs["dag_run"].get_previous_dagrun() is None
-
-
 class UnpaywallDataFeedRelease(StreamRelease):
     """Unpaywall Data Feed Release"""
 

--- a/academic_observatory_workflows/workflows/unpaywall_data_feed_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_data_feed_telescope.py
@@ -1,0 +1,274 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Tuan Chien
+
+import os
+from typing import List
+
+import pendulum
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
+from airflow.exceptions import AirflowException
+from airflow.models.taskinstance import TaskInstance
+from observatory.platform.utils.airflow_utils import (
+    AirflowVars,
+    get_airflow_connection_password,
+)
+from observatory.platform.utils.file_utils import find_replace_file, unzip_files
+from observatory.platform.utils.http_download import download_files
+from observatory.platform.utils.json_util import csv_to_jsonlines
+from observatory.platform.utils.url_utils import (
+    get_http_response_json,
+    get_observatory_http_header,
+)
+from observatory.platform.workflows.stream_telescope import (
+    StreamRelease,
+    StreamTelescope,
+)
+
+
+class UnpaywallDataFeedRelease(StreamRelease):
+    """Unpaywall Data Feed Release"""
+
+    AIRFLOW_CONNECTION = "unpaywall_data_feed"  # Contains API key
+
+    # These links are publicly listed on Unpaywall's website. See https://unpaywall.org/products/data-feed
+    SNAPSHOT_URL = "https://api.unpaywall.org/feed/snapshot"
+    CHANGEFILES_URL = "https://api.unpaywall.org/feed/changefiles"
+
+    def __init__(
+        self,
+        *,
+        dag_id: str,
+        start_date: pendulum.DateTime,
+        end_date: pendulum.DateTime,
+        first_release: bool,
+        max_download_connections: int = 1,
+        update_interval: str = "day",  # Can be "week"
+    ):
+        """Construct an UnpaywallDataFeedRelease instance
+
+        :param dag_id: the id of the DAG.
+        :param start_date: the start_date of the release.
+        :param end_date: the end_date of the release.
+        :param first_release: whether this is the first release that is processed for this DAG
+        :param max_download_connections: max download connections.
+        :param update_interval: Whether to use the daily or weekly diffs.
+        """
+
+        super().__init__(
+            dag_id,
+            start_date,
+            end_date,
+            first_release,
+        )
+
+        if update_interval != "day" and update_interval != "week":
+            raise AirflowException("update_interval can only be day or week")
+
+        self.update_interval = update_interval
+        self.max_download_connections = max_download_connections
+
+    @property
+    def api_key(self) -> str:
+        """The API key for accessing Unpaywall."""
+
+        return get_airflow_connection_password(UnpaywallDataFeedRelease.AIRFLOW_CONNECTION)
+
+    @property
+    def snapshot_url(self) -> str:
+        """Snapshot URL"""
+
+        return f"{UnpaywallDataFeedRelease.SNAPSHOT_URL}?api_key={self.api_key}"
+
+    @property
+    def data_feed_url(self) -> str:
+        """Data Feed URL"""
+
+        return f"{UnpaywallDataFeedRelease.CHANGEFILES_URL}?interval={self.update_interval}&api_key={self.api_key}"
+
+    def download(self):
+        """Download the release."""
+
+        # May need to refactor depending on how snapshot looks.
+        if self.first_release:
+            self.download_snapshot_()
+        else:
+            self.download_data_feed_()
+
+    def download_snapshot_(self):
+        """Download the most recent Unpaywall snapshot on or before the start date."""
+
+        # Query list of available snapshots.
+        # Find the most recent one.
+        # Download most recent one.
+        response = get_http_response_json(self.snapshot_url)
+
+    def download_data_feed_(self):
+        """Download data feed updates (diff) that can be applied to the base snapshot."""
+
+        download_list = list()
+
+        release_info = get_http_response_json(self.data_feed_url)
+        for release in release_info:
+            release_date = release["date"] if self.update_interval == "day" else release["to_date"]
+            release_date = pendulum.parse(release_date)
+
+            if self.start_date <= release_date <= self.end_date:
+                filename = os.path.join(self.download_folder, release["filename"])
+                download_list.append({"url": release["url"], "filename": filename})
+
+        headers = get_observatory_http_header(package_name="academic_observatory_workflows")
+        download_files(download_list=download_list, headers=headers)
+
+    def extract(self):
+        """Unzip the downloaded files."""
+
+        unzip_files(file_list=self.download_files, output_dir=self.extract_folder)
+
+    def transform(self):
+        """Convert any CSV to JSONL as needed.  It's unclear if this is still necessary, but there are examples of CSV
+        in the data feed. The latest being in 2021-01.
+
+        Find and replace the 'authenticated-orcid' string in the jsonl to 'authenticated_orcid'
+        """
+
+        # Convert csv to jsonl and put it in the extract dir
+        self.convert_csv_to_jsonl_()
+
+        # Replace authenticated-orcid string with authenticated_orcid in files
+        self.find_and_replace_strings_()
+
+    def convert_csv_to_jsonl_(self):
+        """Convert CSV to JSONL files as needed."""
+
+        files = filter(lambda file: file[-3:] == "csv", self.extract_files)
+
+        for src_path in files:
+            file = os.path.basename(src_path)
+            dst_file = file + ".jsonl"  # Add json suffix
+            dst_path = os.path.join(self.extract_folder, dst_file)
+            csv_to_jsonlines(csv_file=src_path, jsonl_file=dst_path)
+
+    def find_and_replace_strings_(self):
+        """Find and replace the 'authenticated-orcid' string in the jsonl to 'authenticated_orcid'"""
+
+        files = list(filter(lambda file: file[-5:] == "jsonl", self.extract_files))
+        print(f"FIND AND REPLACE ON: {files}.  extract files: {self.extract_files}")
+
+        for src in files:
+            print(f"Find and replacing {src}")
+            filename = os.path.basename(src)
+            dst = os.path.join(self.transform_folder, filename)
+            find_replace_file(src=src, dst=dst, pattern="authenticated-orcid", replacement="authenticated_orcid")
+
+
+class UnpaywallDataFeedTelescope(StreamTelescope):
+    DAG_ID = "unpaywall_data_feed"
+    DATAFEED_URL = "https://unpaywall.org/products/data-feed"
+
+    def __init__(
+        self,
+        dag_id: str = DAG_ID,
+        start_date: pendulum.DateTime = pendulum.datetime(2021, 7, 2),
+        schedule_interval: str = "@daily",
+        dataset_id: str = "unpaywall_data_feed",
+        dataset_description: str = f"Unpaywall Data Feed: {DATAFEED_URL}",
+        queue: str = "default",
+        merge_partition_field: str = "id",
+        bq_merge_days: int = 7,
+        schema_folder: str = default_schema_folder(),
+        batch_load: bool = False,
+        airflow_vars: List = None,
+        max_download_connections: int = 8,
+    ):
+        """Unpaywall Data Feed telescope.
+
+        :param dag_id: the id of the DAG.
+        :param start_date: the start date of the DAG.
+        :param schedule_interval: the schedule interval of the DAG.
+        :param dataset_id: the dataset id.
+        :param dataset_description: the dataset description.
+        :param queue: the queue that the tasks should run on.
+        :param merge_partition_field: the BigQuery field used to match partitions for a merge
+        :param bq_merge_days: how often partitions should be merged (every x days)
+        :param schema_folder: the SQL schema path.
+        :param batch_load: whether all files in the transform folder are loaded into 1 table at once
+        :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
+        :param max_download_connections: Maximum number of connections allowed for simultaneous downloading of files.
+        """
+
+        if airflow_vars is None:
+            airflow_vars = [
+                AirflowVars.DATA_PATH,
+                AirflowVars.PROJECT_ID,
+                AirflowVars.DATA_LOCATION,
+                AirflowVars.DOWNLOAD_BUCKET,
+                AirflowVars.TRANSFORM_BUCKET,
+            ]
+
+        airflow_conns = ["unpaywall_data_feed"]
+
+        super().__init__(
+            dag_id,
+            start_date,
+            schedule_interval,
+            dataset_id,
+            merge_partition_field,
+            bq_merge_days,
+            schema_folder,
+            dataset_description=dataset_description,
+            queue=queue,
+            batch_load=batch_load,
+            airflow_vars=airflow_vars,
+            airflow_conns=airflow_conns,
+        )
+
+        self.max_download_connections = max_download_connections
+
+        self.add_setup_task_chain([self.check_dependencies, self.get_release_info])
+
+        self.add_task(self.download)
+        self.add_task(self.upload_downloaded)
+        self.add_task(self.extract)
+        self.add_task(self.transform)
+        self.add_task(self.upload_transformed)
+        self.add_task(self.bq_load_partition)
+
+        self.add_task_chain([self.bq_delete_old, self.bq_append_new, self.cleanup], trigger_rule="none_failed")
+
+    def make_release(self, **kwargs) -> UnpaywallDataFeedRelease:
+        """Make a Release instance
+
+        :param kwargs: The context passed from the PythonOperator.
+        :return: UnpaywallDataFeedRelease
+        """
+
+        ti: TaskInstance = kwargs["ti"]
+        start_date, end_date, first_release = ti.xcom_pull(key=self.RELEASE_INFO, include_prior_dates=True)
+
+        start_date = pendulum.parse(start_date)
+        end_date = pendulum.parse(end_date)
+
+        update_interval = "week" if self.schedule_interval == "@weekly" else "day"
+
+        release = UnpaywallDataFeedRelease(
+            dag_id=self.dag_id,
+            start_date=start_date,
+            end_date=end_date,
+            first_release=first_release,
+            update_interval=update_interval,
+            max_download_connections=self.max_download_connections,
+        )
+        return release

--- a/docs/telescopes/index.rst
+++ b/docs/telescopes/index.rst
@@ -15,4 +15,5 @@ output data to other places. Workflows are built on top of Apache Airflow's DAGs
     orcid
     scopus
     unpaywall
+    unpaywall_data_feed
     web_of_science

--- a/docs/telescopes/unpaywall.md
+++ b/docs/telescopes/unpaywall.md
@@ -17,6 +17,18 @@ The Unpaywall snapshot dataset information can be found on the [product page](ht
 
 To give an estimate of dataset size, the 2021-07-02T151134 snapshot is 26 GiB compressed and 177 GiB uncompressed.
 
+## Airflow Connection
+
+The telescope requires an Airflow connection named Airflow http connection named `unpaywall_snapshot` to be set.  The hostname must be set to the URL given to you from Unpaywall for accessing the API to query for snapshot releases (not to be confused with the snapshot download link from the Data Feed service).
+
+For example, the corresponding observatory `config.yaml` entry could be:
+
+```
+unpaywall_snapshot: http://some-valid-unpaywall-snapshot-api.link
+```
+
+The connection must be a valid URI supported by Airflow, but only the hostname is used by this telescope.
+
  ```eval_rst
 +------------------------------+--------------------------------------+
 | Summary                      |                                      |

--- a/docs/telescopes/unpaywall_data_feed.md
+++ b/docs/telescopes/unpaywall_data_feed.md
@@ -31,6 +31,16 @@ Unpaywall recommends applying changefiles starting from a timestamp just before 
 
 The telescope maintains a single updated BigQuery table, that's updated to 2 days before the latest scheduled execution date.
 
+## Airflow Connection
+
+The telescope requires an Airflow connection named `unpaywall_data_feed` with the password set to the API key from Unpaywall for accessing the Data Feed service.  For example, the corresponding observatory `config.yaml` entry could be:
+
+```
+unpaywall_data_feed: http://:API_KEY@localhost
+```
+
+The connection must be a valid URI supported by Airflow, but only the password component (the API key) is used by this telescope.
+
  ```eval_rst
 +------------------------------+--------------------------------------+
 | Summary                      |                                      |

--- a/docs/telescopes/unpaywall_data_feed.md
+++ b/docs/telescopes/unpaywall_data_feed.md
@@ -17,38 +17,39 @@ The free Unpaywall snapshot service is only updated a few times a year.  It is a
 from snapshot to snapshot. The Data Feed service rectifies this by providing daily or weekly changefiles.
 To use the Data Feed:
 1. Get the current snapshot.
-2. Get all changefiles with an update timestamp just before the snapshot date (first changefile) to the current date.
-3. Apply the changefiles to the snapshot in date order.
+2. Get all changefiles starting with latest timestamp just before the snapshot date.
+3. Apply the changefiles to the snapshot in date order from oldest to newest.
 
 The Data Feed service requires an API key in order to access the changefiles.  See the [data feed page](https://unpaywall.org/products/data-feed)
 for more information on obtaining a key.
 
+On first run, this telescope tries to pull the snapshot on the telescope's start date.  Subsequent scheduled runs will download the daily changefile from __TWO DAYS PRIOR__ to the scheduled execution date to update the dataset.  You should set the scheduled_interval to "@daily" or some other equivalent interval which that results in scheduled runs on a daily basis. The telescope attempts to catch up on missed scheduled runs in case of interruption.
+
+The reason that the changefile applied is from two days prior to each scheduled executin date is so that we can guarantee data integrity after applying the snapshot.
+
+Unpaywall recommends applying changefiles starting from a timestamp just before the snapshot timestamp. This telescope uses daily updates. This is to minimise the amount of overlapping data downloaded.  To simplify the update process, we opt to apply daily updates to snapshots starting from one day before the snapshot timestamp. For example, if the first execution date was (2021,7,2), the snapshot frm (2021,7,2) is downloaded.  The next execution date on (2021,7,3) downloads the daily changefile from (2021,7,1).  The next execution date downloads the daily changefile from (2021,7,2).  The next one after that downloads the daily changefile from (2021,7,3), and so on.
+
+The telescope maintains a single updated BigQuery table, that's updated to 2 days before the latest scheduled execution date.
 
  ```eval_rst
 +------------------------------+--------------------------------------+
 | Summary                      |                                      |
 +==============================+======================================+
-| Average runtime              |  ?  min                              |
-+------------------------------+--------------------------------------+
-| Average download size        |  ?  MB                               |
-+------------------------------+--------------------------------------+
 | Harvest Type                 | URL                                  |
 +------------------------------+--------------------------------------+
-| Harvest Frequency            | Daily/Weekly/Monthly/Other           |
+| Harvest Frequency            | Daily                                |
 +------------------------------+--------------------------------------+
-| Runs on remote worker        | True/False                           |
+| Runs on remote worker        | False                                |
 +------------------------------+--------------------------------------+
-| Catchup missed runs          | True/False                           |
+| Catchup missed runs          | True                                 |
 +------------------------------+--------------------------------------+
 | Table Write Disposition      | Append                               |
 +------------------------------+--------------------------------------+
-| Update Frequency             | Daily/Weekly/Monthly/Other           |
+| Update Frequency             | Daily                                |
 +------------------------------+--------------------------------------+
 | Credentials Required         | Yes                                  |
 +------------------------------+--------------------------------------+
 | Uses Workflow Template       | Stream                               |
-+------------------------------+--------------------------------------+
-| Each shard includes all data | No                                   |
 +------------------------------+--------------------------------------+
 ```
 

--- a/docs/telescopes/unpaywall_data_feed.md
+++ b/docs/telescopes/unpaywall_data_feed.md
@@ -1,0 +1,61 @@
+# Unpaywall Data Feed
+
+"Unpaywall is a project of Our Research, a nonprofit building tools to help make scholarly
+research more open, accessible, and reusable." ... they "harvest Open Access content from
+over 50,000 publishers and repositories, and make it easy to find, track, and use."
+-- [Unpaywall website](https://unpaywall.org/).
+
+Unpaywall is an "open database of free scholarly articles." It includes "data from open indexes like Crossref 
+and DOAJ where it exists." Data comes from "monitoring over 50,000 unique online content hosting locations, 
+including Gold OA journals, Hybrid journals, institutional repositories, and disciplinary repositories." 
+"Unpaywall assigns an OA Status to every article." "There are five possible values: closed, green, gold, 
+hybrid, and bronze."
+” _- source: [Unpaywall](https://unpaywall.org/)_ 
+and [data details](https://unpaywall.org/data-format)
+
+The free Unpaywall snapshot service is only updated a few times a year.  It is also difficult to find changes
+from snapshot to snapshot. The Data Feed service rectifies this by providing daily or weekly changefiles.
+To use the Data Feed:
+1. Get the current snapshot.
+2. Get all changefiles with an update timestamp just before the snapshot date (first changefile) to the current date.
+3. Apply the changefiles to the snapshot in date order.
+
+The Data Feed service requires an API key in order to access the changefiles.  See the [data feed page](https://unpaywall.org/products/data-feed)
+for more information on obtaining a key.
+
+
+ ```eval_rst
++------------------------------+--------------------------------------+
+| Summary                      |                                      |
++==============================+======================================+
+| Average runtime              |  ?  min                              |
++------------------------------+--------------------------------------+
+| Average download size        |  ?  MB                               |
++------------------------------+--------------------------------------+
+| Harvest Type                 | URL                                  |
++------------------------------+--------------------------------------+
+| Harvest Frequency            | Daily/Weekly/Monthly/Other           |
++------------------------------+--------------------------------------+
+| Runs on remote worker        | True/False                           |
++------------------------------+--------------------------------------+
+| Catchup missed runs          | True/False                           |
++------------------------------+--------------------------------------+
+| Table Write Disposition      | Append                               |
++------------------------------+--------------------------------------+
+| Update Frequency             | Daily/Weekly/Monthly/Other           |
++------------------------------+--------------------------------------+
+| Credentials Required         | Yes                                  |
++------------------------------+--------------------------------------+
+| Uses Workflow Template       | Stream                               |
++------------------------------+--------------------------------------+
+| Each shard includes all data | No                                   |
++------------------------------+--------------------------------------+
+```
+
+## Latest schema
+``` eval_rst
+.. csv-table::
+   :file: ../schemas/unpaywall_data_feed_latest.csv
+   :width: 100%
+   :header-rows: 1
+```


### PR DESCRIPTION
Unpaywall data feed telescope uses a stream telescope template.
- Fetches daily changefiles
- Start date should be set to the snapshot date you want to base dataset on and be after (2021,7,2).
- Daily update runs will fetch the daily changefile from 2 days prior to the execution_date.  This is so that the first changefile fetched is 1 day prior to the snapshot date (to guarantee data integrity).  In effect, this means the dataset on a given execution_date is 2 days behind the latest changefile.