### PR TITLE
Inf 98/remove get file hash file

### DIFF
--- a/academic_observatory_workflows/fixtures/geonames/fetch_release_date.yaml
+++ b/academic_observatory_workflows/fixtures/geonames/fetch_release_date.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d0ffdef14df189202fe5f4644193d3b1cc81a20015f349676e9247f095be7a54
-size 843

--- a/academic_observatory_workflows/fixtures/geonames/list_releases.yaml
+++ b/academic_observatory_workflows/fixtures/geonames/list_releases.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a186aa88c5102753ae3445995f45cc3c5e3e1277f9eae62657e3e1683c67b5f
-size 843

--- a/academic_observatory_workflows/fixtures/grid/files/22091379
+++ b/academic_observatory_workflows/fixtures/grid/files/22091379
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ae92002a64be5ea196671a59040344dd0b74b72b088117bbc0ee07b6de6833
+size 35939566

--- a/academic_observatory_workflows/fixtures/grid/files/2284777
+++ b/academic_observatory_workflows/fixtures/grid/files/2284777
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21577ba7ddd3bbbeb7cfe98219b58000744c1e54eb94493c5274728fccc8c213
+size 39334445

--- a/academic_observatory_workflows/fixtures/grid/grid_2015-09-22.yaml
+++ b/academic_observatory_workflows/fixtures/grid/grid_2015-09-22.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:443bc3570246ee0a763d27b4912b6eb08e21c999bb7e917f4df7a3074c39a1fc
-size 46848977

--- a/academic_observatory_workflows/fixtures/grid/grid_2020-03-15.yaml
+++ b/academic_observatory_workflows/fixtures/grid/grid_2020-03-15.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:200365835ae887b66218ef558e22c0c1d371d6dd7b0da52e4606e8f2c0be80c7
-size 53598103

--- a/academic_observatory_workflows/fixtures/grid/list_grid_releases
+++ b/academic_observatory_workflows/fixtures/grid/list_grid_releases
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8db1bc8a1cf2edbc9c8202c30d739031a54d46772cbe5cd868cc7c08a320b48f
+size 34016

--- a/academic_observatory_workflows/fixtures/grid/list_grid_releases.yaml
+++ b/academic_observatory_workflows/fixtures/grid/list_grid_releases.yaml
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76bb831c7566d40cbaafc991d64b6d131e8fb80c05fc1ef38bb14d6e147ef78f
-size 5342

--- a/academic_observatory_workflows/fixtures/grid/v2/articles/12022722/files
+++ b/academic_observatory_workflows/fixtures/grid/v2/articles/12022722/files
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0a9baf9629e685f438ac29236d3dfd5011262b967dd6e5bbdfc63986b8df9e3
+size 261

--- a/academic_observatory_workflows/fixtures/grid/v2/articles/1553266/files
+++ b/academic_observatory_workflows/fixtures/grid/v2/articles/1553266/files
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e37af980eec3c4cad627526cb39eb500dfb15db042c912cb0e8f5f6df48167e1
+size 258

--- a/academic_observatory_workflows/fixtures/grid/v2/articles/1553267/files
+++ b/academic_observatory_workflows/fixtures/grid/v2/articles/1553267/files
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3717258e8e01f2bcae9c6e4eaaa5a12a9e68dcad56b623aa7c93b1a44450a4a
+size 260

--- a/academic_observatory_workflows/workflows/geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/geonames_telescope.py
@@ -30,7 +30,7 @@ from academic_observatory_workflows.config import schema_folder as default_schem
 from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
 from observatory.platform.utils.airflow_utils import AirflowVars
-from observatory.platform.utils.data_utils import get_file
+from observatory.platform.utils.http_download import download_file
 from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
@@ -108,11 +108,8 @@ class GeonamesRelease(SnapshotRelease):
         :return: None
         """
 
-        file_path, updated = get_file(
-            fname=self.download_path, origin=GeonamesRelease.DOWNLOAD_URL, cache_subdir="", extract=False
-        )
-
-        logging.info(f"Downloaded file: {file_path}")
+        download_file(url=GeonamesRelease.DOWNLOAD_URL, filename=self.download_path)
+        logging.info(f"Downloaded file: {self.download_path}")
 
     def extract(self):
         """Extract a downloaded Geonames release.

--- a/academic_observatory_workflows/workflows/open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/open_citations_telescope.py
@@ -24,15 +24,13 @@ from dataclasses import dataclass
 from typing import List
 
 import pendulum
+from academic_observatory_workflows.config import schema_folder
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.variable import Variable
 from google.cloud.bigquery import SourceFormat
-
-from academic_observatory_workflows.config import schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars, check_variables
 from observatory.platform.utils.config_utils import find_schema
-from observatory.platform.utils.data_utils import get_file
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,
     bigquery_table_exists,
@@ -40,6 +38,7 @@ from observatory.platform.utils.gc_utils import (
     load_bigquery_table,
     upload_files_to_cloud_storage,
 )
+from observatory.platform.utils.http_download import download_file
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.url_utils import retry_session
 from observatory.platform.utils.workflow_utils import SubFolder, workflow_path
@@ -233,13 +232,7 @@ class OpenCitationsTelescope:
         for release in releases:
             os.makedirs(release.download_path, exist_ok=True)
             for file in release.files:
-                file_path, updated = get_file(
-                    file.name,
-                    file.download_url,
-                    cache_subdir="",
-                    cache_dir=release.download_path,
-                    md5_hash=file.md5hash,
-                )
+                download_file(url=file.download_url, filename=file.name, hash=file.md5hash, hash_algorithm="md5")
 
     @staticmethod
     def upload_downloaded(**kwargs):

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -20,6 +20,9 @@ from unittest.mock import patch
 
 import pendulum
 import vcr
+from airflow.exceptions import AirflowSkipException
+from click.testing import CliRunner
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.crossref_events_telescope import (
     CrossrefEventsRelease,
@@ -27,8 +30,6 @@ from academic_observatory_workflows.workflows.crossref_events_telescope import (
     parse_event_url,
     transform_batch,
 )
-from airflow.exceptions import AirflowSkipException
-from click.testing import CliRunner
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -20,9 +20,6 @@ from unittest.mock import patch
 
 import pendulum
 import vcr
-from airflow.exceptions import AirflowSkipException
-from click.testing import CliRunner
-
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.crossref_events_telescope import (
     CrossrefEventsRelease,
@@ -30,6 +27,8 @@ from academic_observatory_workflows.workflows.crossref_events_telescope import (
     parse_event_url,
     transform_batch,
 )
+from airflow.exceptions import AirflowSkipException
+from click.testing import CliRunner
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -78,8 +77,7 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         dag = CrossrefEventsTelescope().make_dag()
         self.assert_dag_structure(
             {
-                "check_dependencies": ["get_release_info"],
-                "get_release_info": ["download"],
+                "check_dependencies": ["download"],
                 "download": ["upload_downloaded"],
                 "upload_downloaded": ["transform"],
                 "transform": ["upload_transformed"],
@@ -120,20 +118,16 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         # Create the Observatory environment and run tests
         with env.create():
             # first run
-            with env.create_dag_run(dag, self.first_execution_date):
+            with env.create_dag_run(dag, self.first_execution_date) as dag_run:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
-                # Test list releases task with files available
-                ti = env.run_task(telescope.get_release_info.__name__)
-                start_date, end_date, first_release = ti.xcom_pull(
-                    key=CrossrefEventsTelescope.RELEASE_INFO,
-                    task_ids=telescope.get_release_info.__name__,
-                    include_prior_dates=False,
+                start_date, end_date, first_release = telescope.get_release_info(
+                    execution_date=self.first_execution_date,
+                    dag=dag,
+                    dag_run=dag_run,
+                    next_execution_date=pendulum.datetime(2018, 5, 20),
                 )
-
-                start_date = pendulum.parse(start_date)
-                end_date = pendulum.parse(end_date)
 
                 self.assertEqual(start_date, dag.default_args["start_date"])
                 self.assertEqual(end_date, pendulum.today("UTC") - timedelta(days=1))
@@ -206,19 +200,17 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
             # second run
-            with env.create_dag_run(dag, self.second_execution_date):
+            with env.create_dag_run(dag, self.second_execution_date) as dag_run:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
-                # Test list releases task with files available
-                ti = env.run_task(telescope.get_release_info.__name__)
-                start_date, end_date, first_release = ti.xcom_pull(
-                    key=CrossrefEventsTelescope.RELEASE_INFO,
-                    task_ids=telescope.get_release_info.__name__,
-                    include_prior_dates=False,
+                start_date, end_date, first_release = telescope.get_release_info(
+                    execution_date=self.second_execution_date,
+                    dag=dag,
+                    dag_run=dag_run,
+                    next_execution_date=pendulum.datetime(2018, 5, 27),
                 )
-                start_date = pendulum.parse(start_date)
-                end_date = pendulum.parse(end_date)
+
                 self.assertEqual(release.end_date + timedelta(days=1), start_date)
                 self.assertEqual(pendulum.today("UTC") - timedelta(days=1), end_date)
                 self.assertFalse(first_release)

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -31,7 +31,7 @@ from academic_observatory_workflows.workflows.crossref_fundref_telescope import 
     list_releases,
     strip_whitespace,
 )
-from observatory.platform.utils.file_utils import _hash_file
+from observatory.platform.utils.file_utils import get_file_hash
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -215,7 +215,7 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
             file_without_space = "file2.txt"
             with open(file_without_space, "w") as f:
                 f.write("test")
-            expected_hash = _hash_file(file_without_space, algorithm="md5")
+            expected_hash = get_file_hash(file_path=file_without_space, algorithm="md5")
 
             # Strip whitespace and check that files are now the same
             strip_whitespace(file_with_space)

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -19,9 +19,10 @@ from __future__ import annotations
 import os
 from datetime import timedelta
 from typing import Dict, List
-from unittest.mock import patch
 
 import pendulum
+from airflow.exceptions import AirflowException
+
 from academic_observatory_workflows.model import (
     Institution,
     bq_load_observatory_dataset,
@@ -35,7 +36,6 @@ from academic_observatory_workflows.workflows.doi_workflow import (
     make_dataset_transforms,
     make_elastic_tables,
 )
-from airflow.exceptions import AirflowException
 from observatory.platform.utils.airflow_utils import set_task_state
 from observatory.platform.utils.gc_utils import run_bigquery_query
 from observatory.platform.utils.test_utils import (

--- a/academic_observatory_workflows/workflows/tests/test_elastic_import_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_elastic_import_workflow.py
@@ -19,18 +19,14 @@ from __future__ import annotations
 import json
 import logging
 import os
-from observatory.platform.elastic.elastic import Elastic
-from observatory.platform.elastic.kibana import Kibana
+
+from academic_observatory_workflows.config import elastic_mappings_folder
+from academic_observatory_workflows.dags.elastic_import_workflow import load_elastic_mappings_ao
 from observatory.platform.utils.config_utils import module_file_path
 from observatory.platform.utils.file_utils import load_file
 from observatory.platform.utils.jinja2_utils import render_template
 from observatory.platform.utils.test_utils import ObservatoryEnvironment, ObservatoryTestCase
 from observatory.platform.utils.workflow_utils import make_dag_id
-from observatory.platform.workflows.elastic_import_workflow import load_elastic_mappings_simple
-from typing import Dict
-
-from academic_observatory_workflows.config import elastic_mappings_folder
-from academic_observatory_workflows.dags.elastic_import_workflow import load_elastic_mappings_ao
 
 
 class TestElasticImportWorkflow(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -18,6 +18,7 @@ import os
 from unittest.mock import patch
 
 import pendulum
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.geonames_telescope import (
     GeonamesRelease,

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -15,11 +15,9 @@
 # Author: Aniek Roelofs, James Diprose
 
 import os
+from unittest.mock import patch
 
-import httpretty
 import pendulum
-import vcr
-
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.geonames_telescope import (
     GeonamesRelease,
@@ -27,9 +25,10 @@ from academic_observatory_workflows.workflows.geonames_telescope import (
     fetch_release_date,
     first_sunday_of_month,
 )
-from observatory.platform.utils.file_utils import _hash_file
+from observatory.platform.utils.file_utils import get_file_hash
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
 from observatory.platform.utils.test_utils import (
+    HttpServer,
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
@@ -39,6 +38,11 @@ from observatory.platform.utils.workflow_utils import (
     blob_name,
     workflow_path,
 )
+
+
+class MockResponse:
+    def __init__(self, headers):
+        self.headers = headers
 
 
 class TestGeonamesTelescope(ObservatoryTestCase):
@@ -108,15 +112,17 @@ class TestGeonamesTelescope(ObservatoryTestCase):
         actual_datetime = first_sunday_of_month(datetime)
         self.assertEqual(expected_datetime, actual_datetime)
 
-    def test_fetch_release_date(self):
+    @patch("academic_observatory_workflows.workflows.geonames_telescope.requests.head")
+    def test_fetch_release_date(self, m_req):
         """Test fetch_release_date function.
 
         :return: None.
         """
 
-        with vcr.use_cassette(self.fetch_release_date_path):
-            date = fetch_release_date()
-            self.assertEqual(date, pendulum.datetime(year=2020, month=7, day=16, hour=1, minute=22, second=15))
+        m_req.return_value = MockResponse({"Last-Modified": "Thu, 16 Jul 2020 01:22:15 GMT"})
+
+        date = fetch_release_date()
+        self.assertEqual(date, pendulum.datetime(year=2020, month=7, day=16, hour=1, minute=22, second=15))
 
     def test_telescope(self):
         """Test the Geonames telescope end to end.
@@ -147,7 +153,9 @@ class TestGeonamesTelescope(ObservatoryTestCase):
                 env.run_task(telescope.check_dependencies.__name__, dag, execution_date)
 
                 # Test list releases task
-                with vcr.use_cassette(self.list_releases_path):
+                with patch("academic_observatory_workflows.workflows.geonames_telescope.requests.head") as m_req:
+                    m_req.return_value = MockResponse({"Last-Modified": "Fri, 05 Mar 2021 01:34:32 GMT"})
+
                     ti = env.run_task(telescope.fetch_release_date.__name__, dag, execution_date)
 
                 pulled_release_date = ti.xcom_pull(
@@ -159,12 +167,15 @@ class TestGeonamesTelescope(ObservatoryTestCase):
                 self.assertEqual(release_date.date(), pendulum.parse(pulled_release_date).date())
 
                 # Test download task
-                with httpretty.enabled():
-                    self.setup_mock_file_download(GeonamesRelease.DOWNLOAD_URL, self.all_countries_path)
-                    env.run_task(telescope.download.__name__, dag, execution_date)
+                server = HttpServer(test_fixtures_folder("geonames"))
+                with server.create():
+                    with patch.object(
+                        GeonamesRelease, "DOWNLOAD_URL", f"http://{server.host}:{server.port}/allCountries.zip"
+                    ):
+                        env.run_task(telescope.download.__name__, dag, execution_date)
 
                 download_file_path = os.path.join(download_folder, f"{telescope.dag_id}.zip")
-                expected_file_hash = _hash_file(self.all_countries_path, algorithm="md5")
+                expected_file_hash = get_file_hash(file_path=self.all_countries_path, algorithm="md5")
                 self.assert_file_integrity(download_file_path, expected_file_hash, "md5")
 
                 # Test that file uploaded

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -22,14 +22,15 @@ from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pendulum
+from airflow.exceptions import AirflowException
+from click.testing import CliRunner
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.grid_telescope import (
     GridRelease,
     GridTelescope,
     list_grid_records,
 )
-from airflow.exceptions import AirflowException
-from click.testing import CliRunner
 from observatory.platform.utils.file_utils import get_file_hash, gzip_file_crc
 from observatory.platform.utils.test_utils import (
     HttpServer,

--- a/academic_observatory_workflows/workflows/tests/test_mag_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_mag_telescope.py
@@ -16,7 +16,6 @@
 
 import glob
 import os
-import unittest
 from typing import List
 from zipfile import ZipFile
 
@@ -34,9 +33,8 @@ from academic_observatory_workflows.workflows.mag_telescope import (
     transform_mag_file,
     transform_mag_release,
 )
-from observatory.platform.utils.file_utils import _hash_file
 from observatory.platform.utils.gc_utils import upload_files_to_cloud_storage
-from observatory.platform.utils.test_utils import random_id
+from observatory.platform.utils.test_utils import random_id, ObservatoryTestCase
 
 
 def extract_mag_release(file_path: str, unzip_path: str):
@@ -52,7 +50,7 @@ def extract_mag_release(file_path: str, unzip_path: str):
         zip_file.extractall(unzip_path)
 
 
-class TestMagTelescope(unittest.TestCase):
+class TestMagTelescope(ObservatoryTestCase):
     """Tests for the functions used by the MAG telescope"""
 
     def __init__(self, *args, **kwargs):
@@ -203,7 +201,7 @@ class TestMagTelescope(unittest.TestCase):
             result = transform_mag_file(input_file_path, output_file_path)
             self.assertTrue(result)
             expected_file_hash = "5570569e573a517587d3d11ec00eebf9"
-            self.assertEqual(expected_file_hash, _hash_file(output_file_path, algorithm="md5"))
+            self.assert_file_integrity(output_file_path, expected_file_hash, "md5")
 
     def test_transform_mag_release(self):
         """Tests that transform_mag_release transforms an entire MAG release.

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -22,17 +22,18 @@ from types import SimpleNamespace
 from unittest.mock import ANY, patch
 
 import pendulum
+from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.models.connection import Connection
+from airflow.models.variable import Variable
+from botocore.response import StreamingBody
+from click.testing import CliRunner
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.orcid_telescope import (
     OrcidRelease,
     OrcidTelescope,
     transform_single_file,
 )
-from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.models.connection import Connection
-from airflow.models.variable import Variable
-from botocore.response import StreamingBody
-from click.testing import CliRunner
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars, BaseHook
 from observatory.platform.utils.gc_utils import (
     upload_file_to_cloud_storage,

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -18,21 +18,19 @@ import datetime
 import logging
 import os
 import shutil
-import unittest
 from typing import List
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pendulum
 import vcr
+from airflow.utils.state import State
+from click.testing import CliRunner
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.unpaywall_telescope import (
     UnpaywallRelease,
     UnpaywallTelescope,
 )
-from airflow.exceptions import AirflowException
-from airflow.utils.state import State
-from click.testing import CliRunner
-from observatory.platform.utils.file_utils import _hash_file
 from observatory.platform.utils.test_utils import (
     HttpServer,
     ObservatoryEnvironment,
@@ -45,7 +43,7 @@ from observatory.platform.utils.workflow_utils import (
 )
 
 
-class TestUnpaywallRelease(unittest.TestCase):
+class TestUnpaywallRelease(ObservatoryTestCase):
     """Tests for the functions used by the unpaywall telescope"""
 
     def __init__(self, *args, **kwargs):
@@ -99,7 +97,7 @@ class TestUnpaywallRelease(unittest.TestCase):
 
             release.extract()
             self.assertEqual(len(release.extract_files), 1)
-            self.assertEqual(self.unpaywall_test_decompress_hash, _hash_file(release.extract_path, algorithm="md5"))
+            self.assert_file_integrity(release.extract_path, self.unpaywall_test_decompress_hash, "md5")
 
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.get_airflow_connection_url")
     @patch("observatory.platform.utils.workflow_utils.Variable.get")
@@ -124,7 +122,7 @@ class TestUnpaywallRelease(unittest.TestCase):
             release.extract()
             release.transform()
             self.assertEqual(len(release.transform_files), 1)
-            self.assertEqual(self.unpaywall_test_transform_hash, _hash_file(release.transform_path, algorithm="md5"))
+            self.assert_file_integrity(release.transform_path, self.unpaywall_test_transform_hash, "md5")
 
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.get_airflow_connection_url")
     @patch("academic_observatory_workflows.workflows.unpaywall_telescope.Variable.get")


### PR DESCRIPTION
- remove get_file and _hash_file from codebase.
- grid/geonames telescope required changing from vcr to httpserver to serve content to work around aiohttp/vcr incompatibility