### PR TITLE
Inf 121/crossref metadata update

### DIFF
--- a/academic_observatory_workflows/database/schema/crossref_metadata_2021-07-07.json
+++ b/academic_observatory_workflows/database/schema/crossref_metadata_2021-07-07.json
@@ -1991,7 +1991,7 @@
   {
     "mode": "NULLABLE",
     "name": "score",
-    "type": "NUMERIC",
+    "type": "STRING",
     "description": ""
   },
   {

--- a/academic_observatory_workflows/database/schema/crossref_metadata_2021-08-07.json
+++ b/academic_observatory_workflows/database/schema/crossref_metadata_2021-08-07.json
@@ -6,6 +6,48 @@
     "description": "Name of work's publisher."
   },
   {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "issue",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "published_print",
+        "type": "RECORD",
+        "description": "Date on which content was published in print."
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "published_online",
+        "type": "RECORD",
+        "description": "Date on which content was published online."
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "journal_issue",
+    "type": "RECORD",
+    "description": ""
+  },
+  {
     "mode": "REPEATED",
     "name": "title",
     "type": "STRING",
@@ -46,6 +88,26 @@
     "name": "is_referenced_by_count",
     "type": "INTEGER",
     "description": "Count of inbound references deposited with Crossref."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "edition_number",
+    "type": "INTEGER",
+    "description": ""
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published",
+    "type": "RECORD",
+    "description": "Date on which content was published."
   },
   {
     "mode": "NULLABLE",
@@ -318,6 +380,26 @@
     "description": ""
   },
   {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": ""
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "isbn_type",
+    "type": "RECORD",
+    "description": "Date on which content was published."
+  },
+  {
     "mode": "REPEATED",
     "name": "archive",
     "type": "STRING",
@@ -528,11 +610,22 @@
         "mode": "NULLABLE",
         "name": "suffix",
         "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "sequence",
+        "type": "STRING"
       }
     ],
     "mode": "REPEATED",
     "name": "author",
     "type": "RECORD",
+    "description": ""
+  },
+  {
+    "mode": "REPEATED",
+    "name": "institution",
+    "type": "STRING",
     "description": ""
   },
   {
@@ -2121,6 +2214,12 @@
     "mode": "NULLABLE",
     "name": "standards_body",
     "type": "RECORD",
+    "description": ""
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "language",
+    "type": "STRING",
     "description": ""
   }
 ]

--- a/academic_observatory_workflows/database/schema/crossref_metadata_2021-08-07.json
+++ b/academic_observatory_workflows/database/schema/crossref_metadata_2021-08-07.json
@@ -1,257 +1,34 @@
 [
   {
-    "mode": "NULLABLE",
-    "name": "publisher",
-    "type": "STRING",
-    "description": "Name of work's publisher."
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "issue",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "fields": [
-          {
-            "mode": "REPEATED",
-            "name": "date_parts",
-            "type": "INTEGER",
-            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-          }
-        ],
-        "mode": "NULLABLE",
-        "name": "published_print",
-        "type": "RECORD",
-        "description": "Date on which content was published in print."
-      },
-      {
-        "fields": [
-          {
-            "mode": "REPEATED",
-            "name": "date_parts",
-            "type": "INTEGER",
-            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-          }
-        ],
-        "mode": "NULLABLE",
-        "name": "published_online",
-        "type": "RECORD",
-        "description": "Date on which content was published online."
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "journal_issue",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "mode": "REPEATED",
-    "name": "title",
-    "type": "STRING",
-    "description": "Work titles, including translated titles."
-  },
-  {
-    "mode": "REPEATED",
-    "name": "original_title",
-    "type": "STRING",
-    "description": "Work titles in the work's original publication language."
-  },
-  {
-    "mode": "REPEATED",
-    "name": "short_title",
-    "type": "STRING",
-    "description": "Short or abbreviated work titles"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "abstract",
-    "type": "STRING",
-    "description": "Abstract as a JSON string or a JATS XML snippet encoded into a JSON string."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "reference_count",
-    "type": "INTEGER",
-    "description": "Deprecated. Same as references-count."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "references_count",
-    "type": "INTEGER",
-    "description": "Count of outbound references deposited with Crossref"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "is_referenced_by_count",
-    "type": "INTEGER",
-    "description": "Count of inbound references deposited with Crossref."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "edition_number",
-    "type": "INTEGER",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "published",
-    "type": "RECORD",
-    "description": "Date on which content was published."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "source",
-    "type": "STRING",
-    "description": "Currently always Crossref."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "prefix",
-    "type": "STRING",
-    "description": "DOI prefix identifier of the form http://id.crossref.org/prefix/DOI_PREFIX."
-  },
-  {
+    "description": "DOI of the work.",
     "mode": "NULLABLE",
     "name": "DOI",
-    "type": "STRING",
-    "description": "DOI of the work."
+    "type": "STRING"
   },
   {
+    "mode": "REPEATED",
+    "name": "ISBN",
+    "type": "STRING"
+  },
+  {
+    "mode": "REPEATED",
+    "name": "ISSN",
+    "type": "STRING"
+  },
+  {
+    "description": "URL form of the work's DOI.",
     "mode": "NULLABLE",
     "name": "URL",
-    "type": "STRING",
-    "description": "URL form of the work's DOI."
+    "type": "STRING"
   },
   {
+    "description": "Abstract as a JSON string or a JATS XML snippet encoded into a JSON string.",
     "mode": "NULLABLE",
-    "name": "member",
-    "type": "INTEGER",
-    "description": "Member identifier of the form http://id.crossref.org/member/MEMBER_ID"
+    "name": "abstract",
+    "type": "STRING"
   },
   {
-    "mode": "NULLABLE",
-    "name": "type",
-    "type": "STRING",
-    "description": "Enumeration, one of the type ids from https://api.crossref.org/v1/types."
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "timestamp",
-        "type": "INTEGER",
-        "description": "Seconds since UNIX epoch."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "date_time",
-        "type": "TIMESTAMP",
-        "description": "ISO 8601 date time."
-      },
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "created",
-    "type": "RECORD",
-    "description": "Date on which the DOI was first registered."
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "timestamp",
-        "type": "INTEGER",
-        "description": "Seconds since UNIX epoch."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "date_time",
-        "type": "TIMESTAMP",
-        "description": "ISO 8601 date time."
-      },
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "deposited",
-    "type": "RECORD",
-    "description": "Date on which the work metadata was most recently updated."
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "timestamp",
-        "type": "INTEGER",
-        "description": "Seconds since UNIX epoch."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "date_time",
-        "type": "TIMESTAMP",
-        "description": "ISO 8601 date time."
-      },
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "indexed",
-    "type": "RECORD",
-    "description": "Date on which the work metadata was most recently indexed. Re-indexing does not imply a metadata change, see deposited for the most recent metadata change date."
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "issued",
-    "type": "RECORD",
-    "description": "Earliest of published-print and published-online"
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "posted",
-    "type": "RECORD",
-    "description": "Date on which posted content was made available online."
-  },
-  {
+    "description": "Date on which a work was accepted, after being submitted, during a submission process.",
     "fields": [
       {
         "mode": "REPEATED",
@@ -262,58 +39,16 @@
     ],
     "mode": "NULLABLE",
     "name": "accepted",
-    "type": "RECORD",
-    "description": "Date on which a work was accepted, after being submitted, during a submission process."
+    "type": "RECORD"
   },
   {
+    "description": "Other identifiers for the work provided by the depositing member",
     "mode": "REPEATED",
-    "name": "subtitle",
-    "type": "STRING",
-    "description": "Work subtitles, including original language and translated."
+    "name": "alternative_id",
+    "type": "STRING"
   },
   {
-    "mode": "REPEATED",
-    "name": "container_title",
-    "type": "STRING",
-    "description": "Full titles of the containing work (usually a book or journal)"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "short_container_title",
-    "type": "STRING",
-    "description": "Abbreviated titles of the containing work."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "group_title",
-    "type": "STRING",
-    "description": "Group title for posted content."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "issue",
-    "type": "STRING",
-    "description": "Issue number of an article's journal."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "volume",
-    "type": "STRING",
-    "description": "Volume number of an article's journal."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "page",
-    "type": "STRING",
-    "description": "Pages numbers of an article within its journal."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "article_number",
-    "type": "STRING",
-    "description": ""
-  },
-  {
+    "description": "description NA",
     "fields": [
       {
         "mode": "REPEATED",
@@ -323,184 +58,64 @@
       }
     ],
     "mode": "NULLABLE",
-    "name": "published_print",
-    "type": "RECORD",
-    "description": "Date on which the work was published in print."
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "published_online",
-    "type": "RECORD",
-    "description": "Date on which the work was published online."
-  },
-  {
-    "mode": "REPEATED",
-    "name": "subject",
-    "type": "STRING",
-    "description": "Subject category names, a controlled vocabulary from Sci-Val. Available for most journal articles"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "ISSN",
-    "type": "STRING",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "STRING",
-        "description": "ISSN type, can either be print ISSN or electronic ISSN."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING",
-        "description": "ISSN value"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "issn_type",
-    "type": "RECORD",
-    "description": "List of ISSNs with ISSN type information"
-  },
-  {
-    "mode": "REPEATED",
-    "name": "ISBN",
-    "type": "STRING",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "STRING",
-        "description": ""
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "isbn_type",
-    "type": "RECORD",
-    "description": "Date on which content was published."
+    "name": "approved",
+    "type": "RECORD"
   },
   {
     "mode": "REPEATED",
     "name": "archive",
-    "type": "STRING",
-    "description": ""
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "article_number",
+    "type": "STRING"
   },
   {
     "fields": [
       {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "URL",
+            "type": "STRING"
+          }
+        ],
         "mode": "NULLABLE",
-        "name": "content_version",
-        "type": "STRING",
-        "description": "Either vor (version of record,) am (accepted manuscript,) tdm (text and data mining) or unspecified."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "delay_in_days",
-        "type": "INTEGER",
-        "description": "Number of days between the publication date of the work and the start date of this license."
+        "name": "explanation",
+        "type": "RECORD"
       },
       {
         "fields": [
           {
             "mode": "NULLABLE",
-            "name": "timestamp",
-            "type": "INTEGER",
-            "description": "Seconds since UNIX epoch."
+            "name": "label",
+            "type": "STRING"
           },
           {
             "mode": "NULLABLE",
-            "name": "date_time",
-            "type": "STRING",
-            "description": "ISO 8601 date time."
-          },
-          {
-            "mode": "REPEATED",
-            "name": "date_parts",
-            "type": "INTEGER",
-            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+            "name": "name",
+            "type": "STRING"
           }
         ],
         "mode": "NULLABLE",
-        "name": "start",
-        "type": "RECORD",
-        "description": "Date on which this license begins to take effect"
+        "name": "group",
+        "type": "RECORD"
       },
       {
         "mode": "NULLABLE",
-        "name": "URL",
-        "type": "STRING",
-        "description": "Link to a web page describing this license"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "license",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "fields": [
+        "name": "label",
+        "type": "STRING"
+      },
       {
         "mode": "NULLABLE",
         "name": "name",
-        "type": "STRING",
-        "description": "Funding body primary name"
+        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
-        "name": "DOI",
-        "type": "STRING",
-        "description": "Optional Open Funder Registry DOI uniquely identifing the funding body (http://www.crossref.org/fundingdata/registry.html)"
-      },
-      {
-        "mode": "REPEATED",
-        "name": "award",
-        "type": "STRING",
-        "description": "Award number(s) for awards given by the funding body."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "doi_asserted_by",
-        "type": "STRING",
-        "description": "Either crossref or publisher"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "funder",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING",
+        "name": "order",
+        "type": "INTEGER",
         "description": ""
       },
       {
@@ -510,76 +125,34 @@
         "description": ""
       },
       {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "URL",
-            "type": "STRING",
-            "description": ""
-          }
-        ],
         "mode": "NULLABLE",
-        "name": "explanation",
-        "type": "RECORD",
-        "description": ""
-      },
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "assertion",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
       {
         "mode": "NULLABLE",
-        "name": "label",
+        "name": "ORCID",
         "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "order",
-        "type": "INTEGER",
-        "description": ""
+        "description": "URL-form of an ORCID identifier"
       },
       {
         "fields": [
           {
             "mode": "NULLABLE",
             "name": "name",
-            "type": "STRING",
-            "description": ""
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "label",
-            "type": "STRING",
-            "description": ""
+            "type": "STRING"
           }
         ],
-        "mode": "NULLABLE",
-        "name": "group",
-        "type": "RECORD",
-        "description": ""
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "assertion",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING",
-        "description": "URL-form of an ORCID identifier"
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
       },
       {
         "mode": "NULLABLE",
@@ -588,90 +161,24 @@
         "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
       },
       {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING",
-            "description": ""
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD",
-        "description": ""
-      },
-      {
         "mode": "NULLABLE",
-        "name": "name",
+        "name": "family",
         "type": "STRING"
       },
       {
         "mode": "NULLABLE",
-        "name": "suffix",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
         "type": "STRING"
       },
       {
         "mode": "NULLABLE",
         "name": "sequence",
         "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "author",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "mode": "REPEATED",
-    "name": "institution",
-    "type": "STRING",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING",
-        "description": "URL-form of an ORCID identifier"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN",
-        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING",
-            "description": ""
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
       },
       {
         "mode": "NULLABLE",
@@ -680,35 +187,17 @@
       }
     ],
     "mode": "REPEATED",
-    "name": "editor",
-    "type": "RECORD",
-    "description": ""
+    "name": "author",
+    "type": "RECORD"
   },
   {
+    "description": "",
     "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING",
-        "description": ""
-      },
       {
         "mode": "NULLABLE",
         "name": "ORCID",
         "type": "STRING",
         "description": "URL-form of an ORCID identifier"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN",
-        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
       },
       {
         "fields": [
@@ -726,7 +215,30 @@
       },
       {
         "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
         "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "sequence",
         "type": "STRING"
       },
       {
@@ -737,156 +249,10 @@
     ],
     "mode": "REPEATED",
     "name": "chair",
-    "type": "RECORD",
-    "description": ""
+    "type": "RECORD"
   },
   {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "family",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "given",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ORCID",
-        "type": "STRING",
-        "description": "URL-form of an ORCID identifier"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "authenticated_orcid",
-        "type": "BOOLEAN",
-        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "name",
-            "type": "STRING",
-            "description": ""
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "affiliation",
-        "type": "RECORD",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "name",
-        "type": "STRING"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "suffix",
-        "type": "STRING"
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "translator",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "timestamp",
-            "type": "INTEGER",
-            "description": "Seconds since UNIX epoch."
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "date_time",
-            "type": "STRING",
-            "description": "ISO 8601 date time."
-          },
-          {
-            "mode": "REPEATED",
-            "name": "date_parts",
-            "type": "INTEGER",
-            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-          }
-        ],
-        "mode": "NULLABLE",
-        "name": "updated",
-        "type": "RECORD",
-        "description": "Date on which the update was published."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "DOI",
-        "type": "STRING",
-        "description": "DOI of the updated work."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "type",
-        "type": "STRING",
-        "description": "The type of update, for example retraction or correction."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "label",
-        "type": "STRING",
-        "description": "A display-friendly label for the update type."
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "update_to",
-    "type": "RECORD",
-    "description": ""
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "update_policy",
-    "type": "STRING",
-    "description": "Link to an update policy covering Crossmark updates for this work."
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "intended_application",
-        "type": "STRING",
-        "description": "Either text-mining, similarity-checking or unspecified."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "content_version",
-        "type": "STRING",
-        "description": "Either vor (version of record,) am (accepted manuscript) or unspecified."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "content_type",
-        "type": "STRING",
-        "description": "Content type (or MIME type) of the full-text object."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "URL",
-        "type": "STRING",
-        "description": "Direct link to a full-text download location."
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "link",
-    "type": "RECORD",
-    "description": "URLs to full-text locations."
-  },
-  {
+    "description": "",
     "fields": [
       {
         "mode": "NULLABLE",
@@ -909,1197 +275,13 @@
     ],
     "mode": "REPEATED",
     "name": "clinical_trial_number",
-    "type": "RECORD",
-    "description": ""
+    "type": "RECORD"
   },
   {
+    "description": "Full titles of the containing work (usually a book or journal)",
     "mode": "REPEATED",
-    "name": "alternative_id",
-    "type": "STRING",
-    "description": "Other identifiers for the work provided by the depositing member"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "key",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "DOI",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "doi_asserted_by",
-        "type": "STRING",
-        "description": "One of crossref or publisher."
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "issue",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "first_page",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "volume",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "edition",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "component",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "standard_designator",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "standards_body",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "author",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "year",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "unstructured",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "journal_title",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "article_title",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "series_title",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "volume_title",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ISSN",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "issn_type",
-        "type": "STRING",
-        "description": "One of pissn or eissn"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "ISBN",
-        "type": "STRING",
-        "description": ""
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "isbn_type",
-        "type": "STRING",
-        "description": ""
-      }
-    ],
-    "mode": "REPEATED",
-    "name": "reference",
-    "type": "RECORD",
-    "description": "List of references made by the work"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "crossmark_restriction",
-        "type": "BOOLEAN",
-        "description": ""
-      },
-      {
-        "mode": "REPEATED",
-        "name": "domain",
-        "type": "STRING",
-        "description": ""
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "content_domain",
-    "type": "RECORD",
-    "description": "Information on domains that support Crossmark for this work."
-  },
-  {
-    "fields": [
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_format",
-        "type": "RECORD"
-      },
-      {
-        "mode": "REPEATED",
-        "name": "cites",
-        "type": "STRING"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_preprint",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_part",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_review",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_supplemented_by",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_part_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_identical_to",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "references",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_manifestation",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_reply_to",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_based_on",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_review_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_reply",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_replaced_by",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_comment",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "documents",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_version_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_version",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_related_material",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_compiled_by",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_translation",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_translation_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_preprint_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_referenced_by",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_supplement_to",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_variant_form_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "replaces",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_manifestation_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_related_material",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_basis_for",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_comment_on",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "continues",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_continued_by",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_derivation",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_data_basis_for",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_documented_by",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_derived_from",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "has_manuscript",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_manuscript_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "based_on_data",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_original_form_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_varient_form_of",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "requires",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "is_same_as",
-        "type": "RECORD"
-      },
-      {
-        "fields": [
-          {
-            "mode": "NULLABLE",
-            "name": "id_type",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "id",
-            "type": "STRING"
-          },
-          {
-            "mode": "NULLABLE",
-            "name": "asserted_by",
-            "type": "STRING"
-          }
-        ],
-        "mode": "REPEATED",
-        "name": "compiles",
-        "type": "RECORD"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "relation",
-    "type": "RECORD",
-    "description": "Relations to other works."
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "publisher_location",
-    "type": "STRING",
-    "description": "Location of work's publisher"
-  },
-  {
-    "mode": "NULLABLE",
-    "name": "score",
-    "type": "NUMERIC",
-    "description": ""
-  },
-  {
-    "fields": [
-      {
-        "mode": "REPEATED",
-        "name": "date_parts",
-        "type": "INTEGER",
-        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "approved",
-    "type": "RECORD",
-    "description": "description NA"
+    "name": "container_title",
+    "type": "STRING"
   },
   {
     "fields": [
@@ -2112,10 +294,28 @@
     ],
     "mode": "NULLABLE",
     "name": "content_created",
-    "type": "RECORD",
-    "description": "description NA"
+    "type": "RECORD"
   },
   {
+    "description": "Information on domains that support Crossmark for this work.",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "crossmark_restriction",
+        "type": "BOOLEAN"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "domain",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "content_domain",
+    "type": "RECORD"
+  },
+  {
+    "description": "description NA",
     "fields": [
       {
         "mode": "REPEATED",
@@ -2126,21 +326,147 @@
     ],
     "mode": "NULLABLE",
     "name": "content_updated",
-    "type": "RECORD",
-    "description": "description NA"
+    "type": "RECORD"
   },
   {
+    "description": "Date on which the DOI was first registered.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      },
+      {
+        "description": "ISO 8601 date time.",
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "created",
+    "type": "RECORD"
+  },
+  {
+    "description": "description NA",
     "mode": "REPEATED",
     "name": "degree",
-    "type": "STRING",
-    "description": "description NA"
+    "type": "STRING"
+  },
+  {
+    "description": "Date on which the work metadata was most recently updated.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      },
+      {
+        "description": "ISO 8601 date time.",
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "deposited",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "edition_number",
+    "type": "STRING"
   },
   {
     "fields": [
       {
         "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
         "name": "name",
         "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "sequence",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "editor",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "acronym",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "end",
+        "type": "RECORD"
       },
       {
         "mode": "NULLABLE",
@@ -2149,12 +475,7 @@
       },
       {
         "mode": "NULLABLE",
-        "name": "acronym",
-        "type": "STRING"
-      },
-      {
-        "mode": "REPEATED",
-        "name": "sponsor",
+        "name": "name",
         "type": "STRING"
       },
       {
@@ -2163,8 +484,8 @@
         "type": "STRING"
       },
       {
-        "mode": "NULLABLE",
-        "name": "theme",
+        "mode": "REPEATED",
+        "name": "sponsor",
         "type": "STRING"
       },
       {
@@ -2181,17 +502,9 @@
         "type": "RECORD"
       },
       {
-        "fields": [
-          {
-            "mode": "REPEATED",
-            "name": "date_parts",
-            "type": "INTEGER",
-            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
-          }
-        ],
         "mode": "NULLABLE",
-        "name": "end",
-        "type": "RECORD"
+        "name": "theme",
+        "type": "STRING"
       }
     ],
     "mode": "NULLABLE",
@@ -2202,24 +515,1763 @@
     "fields": [
       {
         "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": "Optional Open Funder Registry DOI uniquely identifing the funding body (http://www.crossref.org/fundingdata/registry.html)"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "award",
+        "type": "STRING",
+        "description": "Award number(s) for awards given by the funding body."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING",
+        "description": "Either crossref or publisher"
+      },
+      {
+        "mode": "NULLABLE",
         "name": "name",
+        "type": "STRING",
+        "description": "Funding body primary name"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "funder",
+    "type": "RECORD"
+  },
+  {
+    "description": "Group title for posted content.",
+    "mode": "NULLABLE",
+    "name": "group_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Date on which the work metadata was most recently indexed. Re-indexing does not imply a metadata change, see deposited for the most recent metadata change date.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      },
+      {
+        "description": "ISO 8601 date time.",
+        "mode": "NULLABLE",
+        "name": "date_time",
+        "type": "TIMESTAMP"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "INTEGER",
+        "description": "Seconds since UNIX epoch."
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "indexed",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "acronym",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "department",
         "type": "STRING"
       },
       {
         "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "place",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "institution",
+    "type": "RECORD"
+  },
+  {
+    "description": "Count of inbound references deposited with Crossref.",
+    "mode": "NULLABLE",
+    "name": "is_referenced_by_count",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Date on which content was published.",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "isbn_type",
+    "type": "RECORD"
+  },
+  {
+    "description": "List of ISSNs with ISSN type information",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "ISSN type, can either be print ISSN or electronic ISSN."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "ISSN value"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "issn_type",
+    "type": "RECORD"
+  },
+  {
+    "description": "Issue number of an article's journal.",
+    "mode": "NULLABLE",
+    "name": "issue",
+    "type": "STRING"
+  },
+  {
+    "description": "Earliest of published-print and published-online",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "issued",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "issue",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "published_online",
+        "type": "RECORD",
+        "description": "Date on which content was published online."
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "published_print",
+        "type": "RECORD",
+        "description": "Date on which content was published in print."
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "journal_issue",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "language",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING",
+        "description": "Link to a web page describing this license"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING",
+        "description": "Either vor (version of record,) am (accepted manuscript,) tdm (text and data mining) or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "delay_in_days",
+        "type": "INTEGER",
+        "description": "Number of days between the publication date of the work and the start date of this license."
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          },
+          {
+            "description": "ISO 8601 date time.",
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "TIMESTAMP"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER",
+            "description": "Seconds since UNIX epoch."
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "start",
+        "type": "RECORD",
+        "description": "Date on which this license begins to take effect"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "license",
+    "type": "RECORD"
+  },
+  {
+    "description": "URLs to full-text locations.",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "URL",
+        "type": "STRING",
+        "description": "Direct link to a full-text download location."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_type",
+        "type": "STRING",
+        "description": "Content type (or MIME type) of the full-text object."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "content_version",
+        "type": "STRING",
+        "description": "Either vor (version of record,) am (accepted manuscript) or unspecified."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "intended_application",
+        "type": "STRING",
+        "description": "Either text-mining, similarity-checking or unspecified."
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "link",
+    "type": "RECORD"
+  },
+  {
+    "description": "Member identifier of the form http://id.crossref.org/member/MEMBER_ID",
+    "mode": "NULLABLE",
+    "name": "member",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Work titles in the work's original publication language.",
+    "mode": "REPEATED",
+    "name": "original_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Pages numbers of an article within its journal.",
+    "mode": "NULLABLE",
+    "name": "page",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "part_number",
+    "type": "STRING"
+  },
+  {
+    "description": "Date on which posted content was made available online.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "posted",
+    "type": "RECORD"
+  },
+  {
+    "description": "DOI prefix identifier of the form http://id.crossref.org/prefix/DOI_PREFIX.",
+    "mode": "NULLABLE",
+    "name": "prefix",
+    "type": "STRING"
+  },
+  {
+    "description": "Date on which content was published.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which the work was published online.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_online",
+    "type": "RECORD"
+  },
+  {
+    "description": "Date on which the work was published in print.",
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER",
+        "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_other",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "REPEATED",
+        "name": "date_parts",
+        "type": "INTEGER"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "published_print",
+    "type": "RECORD"
+  },
+  {
+    "description": "Name of work's publisher.",
+    "mode": "NULLABLE",
+    "name": "publisher",
+    "type": "STRING"
+  },
+  {
+    "description": "Location of work's publisher",
+    "mode": "NULLABLE",
+    "name": "publisher_location",
+    "type": "STRING"
+  },
+  {
+    "description": "List of references made by the work",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISBN",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "ISSN",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "article_title",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "author",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "component",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "doi_asserted_by",
+        "type": "STRING",
+        "description": "One of crossref or publisher."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "edition",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "first_page",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "isbn_type",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "issn_type",
+        "type": "STRING",
+        "description": "One of pissn or eissn"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "issue",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "journal_title",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "key",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "series_title",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "standard_designator",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "standards_body",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "unstructured",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "volume",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "volume_title",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "year",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "reference",
+    "type": "RECORD"
+  },
+  {
+    "description": "Deprecated. Same as references-count.",
+    "mode": "NULLABLE",
+    "name": "reference_count",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Count of outbound references deposited with Crossref",
+    "mode": "NULLABLE",
+    "name": "references_count",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Relations to other works.",
+    "fields": [
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "based_on_data",
+        "type": "RECORD"
+      },
+      {
+        "mode": "REPEATED",
+        "name": "cites",
+        "type": "STRING"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "compiles",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "continues",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "documents",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_comment",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_derivation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_format",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_manifestation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_manuscript",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_part",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_preprint",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_related_material",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_reply",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_review",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_translation",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "has_version",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_based_on",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_basis_for",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_comment_on",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_compiled_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_continued_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_data_basis_for",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_derived_from",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_documented_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_identical_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_manifestation_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_manuscript_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_original_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_part_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_preprint_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_referenced_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_related_material",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_replaced_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_reply_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_review_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_same_as",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_supplement_to",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_supplemented_by",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_translation_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_variant_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_varient_form_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "is_version_of",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "references",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "replaces",
+        "type": "RECORD"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "asserted_by",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id",
+            "type": "STRING"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "id_type",
+            "type": "STRING"
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "requires",
+        "type": "RECORD"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "relation",
+    "type": "RECORD"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "competing_interest_statement",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "language",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "recommendation",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "revision",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "revision_round",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "running_number",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "stage",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "review",
+    "type": "RECORD"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "score",
+    "type": "FLOAT"
+  },
+  {
+    "description": "Abbreviated titles of the containing work.",
+    "mode": "REPEATED",
+    "name": "short_container_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Short or abbreviated work titles",
+    "mode": "REPEATED",
+    "name": "short_title",
+    "type": "STRING"
+  },
+  {
+    "description": "Currently always Crossref.",
+    "mode": "NULLABLE",
+    "name": "source",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
         "name": "acronym",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
         "type": "STRING"
       }
     ],
     "mode": "NULLABLE",
     "name": "standards_body",
-    "type": "RECORD",
-    "description": ""
+    "type": "RECORD"
+  },
+  {
+    "description": "Subject category names, a controlled vocabulary from Sci-Val. Available for most journal articles",
+    "mode": "REPEATED",
+    "name": "subject",
+    "type": "STRING"
+  },
+  {
+    "description": "Work subtitles, including original language and translated.",
+    "mode": "REPEATED",
+    "name": "subtitle",
+    "type": "STRING"
   },
   {
     "mode": "NULLABLE",
-    "name": "language",
-    "type": "STRING",
-    "description": ""
+    "name": "subtype",
+    "type": "STRING"
+  },
+  {
+    "description": "Work titles, including translated titles.",
+    "mode": "REPEATED",
+    "name": "title",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "ORCID",
+        "type": "STRING",
+        "description": "URL-form of an ORCID identifier"
+      },
+      {
+        "fields": [
+          {
+            "mode": "NULLABLE",
+            "name": "name",
+            "type": "STRING",
+            "description": ""
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "affiliation",
+        "type": "RECORD",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "authenticated_orcid",
+        "type": "BOOLEAN",
+        "description": "If true, record owner asserts that the ORCID user completed ORCID OAuth authentication."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "family",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "given",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "name",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "sequence",
+        "type": "STRING"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "suffix",
+        "type": "STRING"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "translator",
+    "type": "RECORD"
+  },
+  {
+    "description": "Enumeration, one of the type ids from https://api.crossref.org/v1/types.",
+    "mode": "NULLABLE",
+    "name": "type",
+    "type": "STRING"
+  },
+  {
+    "description": "Link to an update policy covering Crossmark updates for this work.",
+    "mode": "NULLABLE",
+    "name": "update_policy",
+    "type": "STRING"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "DOI",
+        "type": "STRING",
+        "description": "DOI of the updated work."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "label",
+        "type": "STRING",
+        "description": "A display-friendly label for the update type."
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "type",
+        "type": "STRING",
+        "description": "The type of update, for example retraction or correction."
+      },
+      {
+        "fields": [
+          {
+            "mode": "REPEATED",
+            "name": "date_parts",
+            "type": "INTEGER",
+            "description": "Contains an ordered array of year, month, day of month. Only year is required. Note that the field contains a nested array, e.g. [ [ 2006, 5, 19 ] ] to conform to citeproc JSON dates"
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "date_time",
+            "type": "TIMESTAMP",
+            "description": "ISO 8601 date time."
+          },
+          {
+            "mode": "NULLABLE",
+            "name": "timestamp",
+            "type": "INTEGER",
+            "description": "Seconds since UNIX epoch."
+          }
+        ],
+        "mode": "NULLABLE",
+        "name": "updated",
+        "type": "RECORD",
+        "description": "Date on which the update was published."
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "update_to",
+    "type": "RECORD"
+  },
+  {
+    "description": "Volume number of an article's journal.",
+    "mode": "NULLABLE",
+    "name": "volume",
+    "type": "STRING"
   }
 ]

--- a/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
@@ -287,7 +287,8 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
         # doesn't exist
         releases_list_out = []
         for release in releases_list:
-            table_id = bigquery_sharded_table_id(CrossrefFundrefTelescope.DAG_ID, release["date"])
+            release_date = pendulum.parse(release["date"])
+            table_id = bigquery_sharded_table_id(CrossrefFundrefTelescope.DAG_ID, release_date)
             logging.info("Checking if bigquery table already exists:")
             if bigquery_table_exists(project_id, self.dataset_id, table_id):
                 logging.info(
@@ -295,7 +296,6 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
                 )
             else:
                 logging.info(f"Table does not exist yet, processing {release['url']} in this workflow")
-                release["date"] = release["date"].format("YYYYMMDD")
                 releases_list_out.append(release)
 
         # If releases_list_out contains items then the DAG will continue (return True) otherwise it will

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -380,6 +380,12 @@ def transform_file(input_file_path: str, output_file_path: str):
 
 
 def transform_item(item):
+    """Transform a single Crossref Metadata JSON value.
+
+    :param item: a JSON value.
+    :return: the transformed item.
+    """
+
     if isinstance(item, dict):
         new = {}
         for k, v in item.items():

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -129,6 +129,7 @@ class CrossrefMetadataRelease(SnapshotRelease):
         Each extracted file is transformed. This is done in parallel using the ThreadPoolExecutor.
 
         :param max_processes: the number of processes to use when transforming files (one process per file).
+        :param batch_size: the number of files to send to ProcessPoolExecutor at one time.
         :return: whether the transformation was successful or not.
         """
         logging.info(f"Transform input folder: {self.extract_folder}, output folder: {self.transform_folder}")

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -387,16 +387,11 @@ def transform_item(item):
             k = k.replace("-", "_")
 
             # Get inner array for date parts
-            # "date-parts" : [ [ null ] ]
             if k == "date_parts":
                 v = v[0]
                 if None in v:
+                    # "date-parts" : [ [ null ] ]
                     v = []
-
-            # elif k == "timestamp":
-            #     if isinstance(v, str) and v.startswith("_"):
-            #         logging.warning(f"String timestamp: {v}")
-            #         v = int(v.replace("_", ""))
 
             new[k] = transform_item(v)
         return new

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -39,7 +39,7 @@ from academic_observatory_workflows.config import schema_folder as default_schem
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.url_utils import retry_session
-from observatory.platform.utils.workflow_utils import get_chunks, blob_name, bq_load_shard
+from observatory.platform.utils.workflow_utils import blob_name, bq_load_shard, get_chunks
 from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
@@ -387,16 +387,16 @@ def transform_item(item):
             k = k.replace("-", "_")
 
             # Get inner array for date parts
+            # "date-parts" : [ [ null ] ]
             if k == "date_parts":
+                v = v[0]
                 if None in v:
-                    logging.warning("None in date_parts")
                     v = []
-                else:
-                    v = v[0]
-            elif k == "timestamp":
-                if isinstance(v, str) and v.startswith("_"):
-                    logging.warning(f"String timestamp: {v}")
-                    v = int(v.replace("_", ""))
+
+            # elif k == "timestamp":
+            #     if isinstance(v, str) and v.startswith("_"):
+            #         logging.warning(f"String timestamp: {v}")
+            #         v = int(v.replace("_", ""))
 
             new[k] = transform_item(v)
         return new

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -122,7 +122,7 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
                 release_info = [
                     {
                         "url": "https://gitlab.com/crossref/open_funder_registry/-/archive/v1.34/open_funder_registry-v1.34.tar.gz",
-                        "date": pendulum.parse("2021-05-19T09:34:09.898000+00:00"),
+                        "date": "2021-05-19T09:34:09.898000+00:00",
                     }
                 ]
                 with patch(

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -16,6 +16,7 @@
 
 
 import os
+import unittest
 from datetime import datetime
 from unittest.mock import patch
 
@@ -254,6 +255,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
             with self.assertRaises(AirflowException):
                 telescope.check_release_exists(execution_date=release.release_date)
 
+    @unittest.skip
     @patch("academic_observatory_workflows.workflows.crossref_metadata_telescope.subprocess.Popen")
     def test_transform_file(self, mock_subprocess):
         """Test transform_file function with failing transform command.

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -14,9 +14,8 @@
 
 # Author: Aniek Roelofs
 
-
+import json
 import os
-import unittest
 from datetime import datetime
 from unittest.mock import patch
 
@@ -24,15 +23,18 @@ import httpretty
 import pendulum
 from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
+from click.testing import CliRunner
 from natsort import natsorted
 
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.crossref_metadata_telescope import (
     CrossrefMetadataRelease,
     CrossrefMetadataTelescope,
+    transform_item,
     transform_file,
 )
 from observatory.platform.utils.airflow_utils import AirflowConns
+from observatory.platform.utils.file_utils import load_jsonl
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
@@ -255,15 +257,147 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
             with self.assertRaises(AirflowException):
                 telescope.check_release_exists(execution_date=release.release_date)
 
-    @unittest.skip
-    @patch("academic_observatory_workflows.workflows.crossref_metadata_telescope.subprocess.Popen")
-    def test_transform_file(self, mock_subprocess):
-        """Test transform_file function with failing transform command.
+    def test_transform_file(self):
+        """Test transform_file."""
 
-        :param mock_subprocess: Mock the subprocess output
-        :return: None.
-        """
-        mock_subprocess().returncode = 1
-        mock_subprocess().communicate.return_value = "stdout".encode(), "stderr".encode()
-        with self.assertRaises(AirflowException):
-            transform_file("input_file_path", "output_file_path")
+        with CliRunner().isolated_filesystem() as t:
+            # Save input file
+            input_file_path = os.path.join(t, "input.json")
+            input_data = {
+                "items": [
+                    {
+                        "indexed": {
+                            "date-parts": [[2019, 11, 19]],
+                            "date-time": "2019-11-19T10:09:18Z",
+                            "timestamp": 1574158158980,
+                        },
+                        "reference-count": 0,
+                        "publisher": "American Medical Association (AMA)",
+                        "issue": "2",
+                        "content-domain": {"domain": [], "crossmark-restriction": False},
+                        "short-container-title": [],
+                        "published-print": {"date-parts": [[1994, 2, 1]]},
+                        "DOI": "10.1001/archderm.130.2.225",
+                        "type": "journal-article",
+                        "created": {
+                            "date-parts": [[2003, 3, 18]],
+                            "date-time": "2003-03-18T21:22:40Z",
+                            "timestamp": 1048022560000,
+                        },
+                        "page": "225-232",
+                        "source": "Crossref",
+                        "is-referenced-by-count": 23,
+                        "title": ["Abnormalities of p53 protein expression in cutaneous disorders"],
+                        "prefix": "10.1001",
+                        "volume": "130",
+                        "author": [{"given": "N. S.", "family": "McNutt", "affiliation": []}],
+                        "member": "10",
+                        "container-title": ["Archives of Dermatology"],
+                        "original-title": [],
+                        "deposited": {
+                            "date-parts": [[2011, 7, 21]],
+                            "date-time": "2011-07-21T07:23:09Z",
+                            "timestamp": 1311232989000,
+                        },
+                        "score": None,
+                        "subtitle": [],
+                        "short-title": [],
+                        "issued": {"date-parts": [[1994, 2, 1]]},
+                        "references-count": 0,
+                        "URL": "http://dx.doi.org/10.1001/archderm.130.2.225",
+                        "relation": {},
+                        "ISSN": ["0003-987X"],
+                        "issn-type": [{"value": "0003-987X", "type": "print"}],
+                    }
+                ]
+            }
+
+            with open(input_file_path, mode="w") as f:
+                json.dump(input_data, f)
+
+            # Load Transform file
+            output_file_path = os.path.join(t, "output.jsonl")
+            transform_file(input_file_path, output_file_path)
+
+            # Check results
+            expected_results = [
+                {
+                    "indexed": {
+                        "date_parts": [2019, 11, 19],
+                        "date_time": "2019-11-19T10:09:18Z",
+                        "timestamp": 1574158158980,
+                    },
+                    "reference_count": 0,
+                    "publisher": "American Medical Association (AMA)",
+                    "issue": "2",
+                    "content_domain": {"domain": [], "crossmark_restriction": False},
+                    "short_container_title": [],
+                    "published_print": {"date_parts": [1994, 2, 1]},
+                    "DOI": "10.1001/archderm.130.2.225",
+                    "type": "journal-article",
+                    "created": {
+                        "date_parts": [2003, 3, 18],
+                        "date_time": "2003-03-18T21:22:40Z",
+                        "timestamp": 1048022560000,
+                    },
+                    "page": "225-232",
+                    "source": "Crossref",
+                    "is_referenced_by_count": 23,
+                    "title": ["Abnormalities of p53 protein expression in cutaneous disorders"],
+                    "prefix": "10.1001",
+                    "volume": "130",
+                    "author": [{"given": "N. S.", "family": "McNutt", "affiliation": []}],
+                    "member": "10",
+                    "container_title": ["Archives of Dermatology"],
+                    "original_title": [],
+                    "deposited": {
+                        "date_parts": [2011, 7, 21],
+                        "date_time": "2011-07-21T07:23:09Z",
+                        "timestamp": 1311232989000,
+                    },
+                    "score": None,
+                    "subtitle": [],
+                    "short_title": [],
+                    "issued": {"date_parts": [1994, 2, 1]},
+                    "references_count": 0,
+                    "URL": "http://dx.doi.org/10.1001/archderm.130.2.225",
+                    "relation": {},
+                    "ISSN": ["0003-987X"],
+                    "issn_type": [{"value": "0003-987X", "type": "print"}],
+                }
+            ]
+            actual_results = load_jsonl(output_file_path)
+            self.assertEqual(expected_results, actual_results)
+
+    def test_transform_item(self):
+        """Test the cases that transform_item transforms"""
+
+        # Replace hyphens with underscores
+        item = {
+            "hello": {},
+            "hello-world": {"hello-world": [{"hello-world": 1}, {"hello-world": 1}, {"hello-world": 1}]},
+        }
+        expected = {
+            "hello": {},
+            "hello_world": {"hello_world": [{"hello_world": 1}, {"hello_world": 1}, {"hello_world": 1}]},
+        }
+        actual = transform_item(item)
+        self.assertEqual(expected, actual)
+
+        # date-parts
+        item = {"date-parts": [[2021, 1, 1]]}
+        expected = {"date_parts": [2021, 1, 1]}
+        actual = transform_item(item)
+        self.assertEqual(expected, actual)
+
+        # date-parts with None inside inner list
+        item = {"date-parts": [[None]]}
+        expected = {"date_parts": []}
+        actual = transform_item(item)
+        self.assertEqual(expected, actual)
+
+        # list with date-parts
+        item = {"hello-world": {"hello-world": [{"date-parts": [[2021, 1, 1]]}, {"date-parts": [[None]]}]}}
+        expected = {"hello_world": {"hello_world": [{"date_parts": [2021, 1, 1]}, {"date_parts": []}]}}
+        actual = transform_item(item)
+        self.assertEqual(expected, actual)

--- a/requirements.sh
+++ b/requirements.sh
@@ -15,8 +15,8 @@
 
 # Author: Aniek Roelofs, James Diprose
 
-# Crossref Metadata (pigz mawk), Unpaywall (unzip), Open Citations (unzip)
-apt-get install pigz mawk unzip -y
+# Crossref Metadata (pigz), Open Citations (unzip)
+apt-get install pigz unzip -y
 
 # ORCID: install Google Cloud SDK as root user, used in
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \


### PR DESCRIPTION
This PR addresses the following:
* More robust Crossref Metadata transform step:
  * Can transform JSON input files whether pretty printed or not.
  * Refactored transform functions to use Python rather than mawk as it is easier to understand what the transformation does and it is faster. 11 hrs 16 mins for mawk on latest dataset and 3 hrs 41 mins with Python. I suspect it would be faster if the JSON input files were not pretty printed.
  * Added explicit tests for transform_file and transform_item.
* Latest Crossref Metadata schema.
* Fix bug in Fundref get_release_info, which was passing a string to bigquery_sharded_table_id rather than a DateTime.