### PR TITLE
Ignore unknown fields

### DIFF
--- a/academic_observatory_workflows/workflows/crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_events_telescope.py
@@ -26,7 +26,9 @@ import jsonlines
 import pendulum
 import requests
 from airflow.exceptions import AirflowSkipException
-from airflow.models.taskinstance import TaskInstance
+from tenacity import RetryError, retry, stop_after_attempt, wait_exponential, wait_fixed
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.url_utils import get_user_agent
 from observatory.platform.utils.workflow_utils import upload_files_from_list
@@ -34,9 +36,6 @@ from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,
 )
-from tenacity import RetryError, retry, stop_after_attempt, wait_exponential, wait_fixed
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class CrossrefEventsRelease(StreamRelease):
@@ -263,6 +262,7 @@ class CrossrefEventsTelescope(StreamTelescope):
             queue=queue,
             batch_load=batch_load,
             airflow_vars=airflow_vars,
+            load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
         self.mailto = mailto
         self.max_threads = max_threads

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -298,6 +298,9 @@ class OrcidTelescope(StreamTelescope):
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
             batch_load=batch_load,
+            load_bigquery_table_kwargs={
+                "ignore_unknown_values": True
+            }
         )
         self.max_processes = max_processes
 

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -298,9 +298,7 @@ class OrcidTelescope(StreamTelescope):
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
             batch_load=batch_load,
-            load_bigquery_table_kwargs={
-                "ignore_unknown_values": True
-            }
+            load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
         self.max_processes = max_processes
 

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -218,9 +218,7 @@ class UnpaywallTelescope(StreamTelescope):
             catchup=catchup,
             airflow_vars=airflow_vars,
             airflow_conns=[UnpaywallTelescope.AIRFLOW_CONNECTION],
-            load_bigquery_table_kwargs={
-                "ignore_unknown_values": True
-            }
+            load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
 
         self.add_setup_task(self.check_dependencies)

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -218,6 +218,9 @@ class UnpaywallTelescope(StreamTelescope):
             catchup=catchup,
             airflow_vars=airflow_vars,
             airflow_conns=[UnpaywallTelescope.AIRFLOW_CONNECTION],
+            load_bigquery_table_kwargs={
+                "ignore_unknown_values": True
+            }
         )
 
         self.add_setup_task(self.check_dependencies)


### PR DESCRIPTION
Set the ignore_unknown_values field to True for StreamTelescope subclasses, so that when new fields are added to source data, BigQuery loading will not break.