### PR TITLE
Fix crossref metadata invalid timestamp

### DIFF
--- a/academic_observatory_workflows/fixtures/crossref_metadata/crossref_metadata.json.tar.gz
+++ b/academic_observatory_workflows/fixtures/crossref_metadata/crossref_metadata.json.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d1c56d3f56c409c5ff05a4c2ae172262aa0b743454865a7b91d58157222584de
-size 3206
+oid sha256:5e6d57cb5dec0263adc9b99a3d569a8bc38b97c859413e8a128571e3731db8ec
+size 3054

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -24,9 +24,9 @@ import os
 import shutil
 import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime
 from subprocess import Popen
 from typing import Dict, List
-from datetime import datetime
 
 import jsonlines
 import pendulum
@@ -35,8 +35,6 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from bs4 import BeautifulSoup
 from natsort import natsorted
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.url_utils import retry_session
@@ -45,6 +43,8 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class CrossrefMetadataRelease(SnapshotRelease):

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -26,6 +26,7 @@ import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from subprocess import Popen
 from typing import Dict, List
+from datetime import datetime
 
 import jsonlines
 import pendulum
@@ -402,6 +403,11 @@ def transform_item(item):
             elif k == "award":
                 if isinstance(v, str):
                     v = [v]
+            elif k == "date_time":
+                try:
+                    datetime.strptime(v, "%Y-%m-%dT%H:%M:%SZ")
+                except ValueError:
+                    v = ""
 
             new[k] = transform_item(v)
         return new

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -59,14 +59,14 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
         self.download_path = test_fixtures_folder("crossref_metadata", "crossref_metadata.json.tar.gz")
         self.extract_file_hashes = [
-            "4a55065d90aaa58c69bc5f5a54da3006",
+            "42cab8ed20ef20bed51dacd3dc364589",
             "c45901a52154789470410aad51485e9c",
             "4c0fd617224a557b9ef04313cca0bd4a",
             "d93dc613e299871925532d906c3a44a1",
             "dd1ab247c55191a14bcd1bf32719c337",
         ]
         self.transform_hashes = [
-            "065a8c0bd1ef4239be9f37c0ad199a31",
+            "a2be39d3c4d4c9dc20af768f8ae35476",
             "38b766ec494054e621787de00ff715c8",
             "70437aad7c4568ed07408baf034871e4",
             "c3e3285a48867c8b7c10b1c9c0c5ab8a",
@@ -149,7 +149,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
                     self.setup_mock_file_download(release.url, self.download_path)
                     env.run_task(telescope.download.__name__)
                 self.assertEqual(1, len(release.download_files))
-                expected_file_hash = "10210c33936f9ba6b7e053f6f457591b"
+                expected_file_hash = "047770ae386f3376c08e3975d7f06016"
                 self.assert_file_integrity(release.download_path, expected_file_hash, "md5")
 
                 # Test that file uploaded

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -121,7 +121,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         dataset_id = env.add_dataset()
 
         # Setup Telescope
-        execution_date = pendulum.datetime(year=2020, month=11, day=1)
+        execution_date = pendulum.datetime(year=2022, month=1, day=1)
         telescope = CrossrefMetadataTelescope(dataset_id=dataset_id)
         dag = telescope.make_dag()
 


### PR DESCRIPTION
Some entries have an invalid date_time field, resulting in a BigQuery loading error (I've made the date_time field a STRING here to display the faulty entry).
![image](https://user-images.githubusercontent.com/22207600/150284614-8764bbc7-c95c-4704-bac7-4bd2069ce257.png)

This PR adds a Try/Except check to verify the value for a 'date_time' field. This field is of the 'TIMESTAMP type in BigQuery.
If the value is not a valid datetime, the 'date_time' field will be set to null.

Other date related fields like 'timestamp' (INTEGER) and 'date_parts' (ARRAY of INTEGER) in the same STRUCT remain unchanged, regardless whether 'date_time' is valid or not.

So the above result would now be:
![image](https://user-images.githubusercontent.com/22207600/150284543-90348711-2d65-4b2a-88e0-976e4b7e356c.png)


I've changed the fixture and updated the unit tests to test for an invalid date_time, however this does not seem to be picked up by codecov. I suspect that is because it is run from the ProcessPoolExecutor.