### PR TITLE
INF-328: Ignore unknown values on BigQuery load

### DIFF
--- a/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
@@ -181,6 +181,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
         schedule_interval: str = "@weekly",
         dataset_id: str = DATASET_ID,
         schema_folder: str = default_schema_folder(),
+        load_bigquery_table_kwargs: Dict = None,
         table_descriptions: Dict = None,
         catchup: bool = True,
         airflow_vars: List = None,
@@ -193,6 +194,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
         :param schedule_interval: the schedule interval of the DAG.
         :param dataset_id: the BigQuery dataset id.
         :param schema_folder: the SQL schema path.
+        :param load_bigquery_table_kwargs: the customisation parameters for loading data into a BigQuery table.
         :param table_descriptions: a dictionary with table ids and corresponding table descriptions.
         :param catchup: whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
@@ -211,12 +213,17 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
                 AirflowVars.DOWNLOAD_BUCKET,
                 AirflowVars.TRANSFORM_BUCKET,
             ]
+
+        if load_bigquery_table_kwargs is None:
+            load_bigquery_table_kwargs = {"ignore_unknown_values": True}
+
         super().__init__(
             dag_id,
             start_date,
             schedule_interval,
             dataset_id,
             schema_folder,
+            load_bigquery_table_kwargs=load_bigquery_table_kwargs,
             table_descriptions=table_descriptions,
             catchup=catchup,
             airflow_vars=airflow_vars,

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -218,6 +218,10 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
             ]
         if airflow_conns is None:
             airflow_conns = [AirflowConns.CROSSREF]
+
+        if load_bigquery_table_kwargs is None:
+            load_bigquery_table_kwargs = {"ignore_unknown_values": True}
+
         super().__init__(
             dag_id,
             start_date,
@@ -225,8 +229,8 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
             dataset_id,
             schema_folder,
             queue=queue,
-            load_bigquery_table_kwargs=load_bigquery_table_kwargs,
             dataset_description=dataset_description,
+            load_bigquery_table_kwargs=load_bigquery_table_kwargs,
             table_descriptions=table_descriptions,
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,

--- a/academic_observatory_workflows/workflows/geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/geonames_telescope.py
@@ -171,7 +171,11 @@ class GeonamesTelescope(SnapshotTelescope):
         """
 
         if load_bigquery_table_kwargs is None:
-            load_bigquery_table_kwargs = {"csv_field_delimiter": "\t", "csv_quote_character": ""}
+            load_bigquery_table_kwargs = {
+                "csv_field_delimiter": "\t",
+                "csv_quote_character": "",
+                "ignore_unknown_values": True,
+            }
 
         if table_descriptions is None:
             table_descriptions = {dag_id: "The GeoNames table."}

--- a/academic_observatory_workflows/workflows/open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/open_citations_telescope.py
@@ -118,6 +118,7 @@ class OpenCitationsTelescope(SnapshotTelescope):
             "csv_skip_leading_rows": 1,
             "csv_allow_quoted_newlines": True,
             "write_disposition": bigquery.WriteDisposition.WRITE_APPEND,
+            "ignore_unknown_values": True
         }
 
         if table_descriptions is None:

--- a/academic_observatory_workflows/workflows/scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/scopus_telescope.py
@@ -202,6 +202,7 @@ class ScopusTelescope(SnapshotTelescope):
 
         load_bigquery_table_kwargs = {
             "write_disposition": WriteDisposition.WRITE_APPEND,
+            "ignore_unknown_values": True
         }
 
         super().__init__(

--- a/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
@@ -20,7 +20,6 @@ import re
 from typing import Dict, List, Union
 
 import pendulum
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.models import Variable
 from airflow.models.taskinstance import TaskInstance
 from observatory.platform.utils.airflow_utils import (
@@ -41,6 +40,8 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class UnpaywallSnapshotRelease(SnapshotRelease):
@@ -146,6 +147,7 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         dataset_id: str = "our_research",
         queue: str = "remote_queue",
         schema_folder: str = default_schema_folder(),
+        load_bigquery_table_kwargs: Dict = None,
         table_descriptions: Dict = None,
         catchup: bool = True,
         airflow_vars: Union[List[AirflowVars], None] = None,
@@ -158,6 +160,7 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         :param dataset_id: GCP dataset ID.
         :param queue: Airflow worker queue to use.
         :param schema_folder: Folder containing the database schemas.
+        :param load_bigquery_table_kwargs: the customisation parameters for loading data into a BigQuery table.
         :param table_descriptions: Descriptions of the tables.
         :param catchup: Whether Airflow should catch up past dag runs.
         :param airflow_vars: List of Airflow variables to use.
@@ -177,12 +180,16 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
 
         airflow_conns = [UnpaywallSnapshotRelease.AIRFLOW_CONNECTION]
 
+        if load_bigquery_table_kwargs is None:
+            load_bigquery_table_kwargs = {"ignore_unknown_values": True}
+
         super().__init__(
             dag_id,
             start_date,
             schedule_interval,
             dataset_id,
             schema_folder,
+            load_bigquery_table_kwargs=load_bigquery_table_kwargs,
             table_descriptions=table_descriptions,
             catchup=catchup,
             airflow_vars=airflow_vars,

--- a/academic_observatory_workflows/workflows/web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/web_of_science_telescope.py
@@ -903,6 +903,7 @@ class WebOfScienceTelescope(SnapshotTelescope):
 
         load_bigquery_table_kwargs = {
             "write_disposition": WriteDisposition.WRITE_APPEND,
+            "ignore_unknown_values": True
         }
 
         super().__init__(


### PR DESCRIPTION
Enable easier maintenance of snapshot telescopes by setting ignore_unknown_values to True.

This means that the production system will not break due to schema additions to datasets. When we want to use new fields from datasets we will need to explicitly update the schema and the next version of a given dataset will have the updated schema (or a current one if we overwrite it).