### PR TITLE
Inf 326/dataset release creation

### DIFF
--- a/academic_observatory_workflows/dags/crossref_events_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_events_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=CrossrefEventsTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = CrossrefEventsTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = CrossrefEventsTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/crossref_events_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_events_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=CrossrefEventsTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=CrossrefEventsTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = CrossrefEventsTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/crossref_events_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_events_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.crossref_events_telescope import CrossrefEventsTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = CrossrefEventsTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=CrossrefEventsTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = CrossrefEventsTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_fundref_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=CrossrefFundrefTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = CrossrefFundrefTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = CrossrefFundrefTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_fundref_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=CrossrefFundrefTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=CrossrefFundrefTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = CrossrefFundrefTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_fundref_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.crossref_fundref_telescope import CrossrefFundrefTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = CrossrefFundrefTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=CrossrefFundrefTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = CrossrefFundrefTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_metadata_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.crossref_metadata_telescope import CrossrefMetadataTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = CrossrefMetadataTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=CrossrefMetadataTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = CrossrefMetadataTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_metadata_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=CrossrefMetadataTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=CrossrefMetadataTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = CrossrefMetadataTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_metadata_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=CrossrefMetadataTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = CrossrefMetadataTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = CrossrefMetadataTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/doi_workflow.py
+++ b/academic_observatory_workflows/dags/doi_workflow.py
@@ -44,7 +44,11 @@ Every week the following tables are overwritten for visualisation in the Data St
 """
 
 from academic_observatory_workflows.workflows.doi_workflow import DoiWorkflow
+from observatory.platform.utils.api import make_observatory_api
 
-# Outputs data into:
-doi_workflow = DoiWorkflow()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=DoiWorkflow.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+doi_workflow = DoiWorkflow(workflow_id=telescopes[0].id)
 globals()[doi_workflow.dag_id] = doi_workflow.make_dag()

--- a/academic_observatory_workflows/dags/doi_workflow.py
+++ b/academic_observatory_workflows/dags/doi_workflow.py
@@ -49,6 +49,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=DoiWorkflow.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-doi_workflow = DoiWorkflow(workflow_id=telescopes[0].id)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+doi_workflow = DoiWorkflow(workflow_id=workflows[0].id)
 globals()[doi_workflow.dag_id] = doi_workflow.make_dag()

--- a/academic_observatory_workflows/dags/doi_workflow.py
+++ b/academic_observatory_workflows/dags/doi_workflow.py
@@ -48,7 +48,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=DoiWorkflow.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=DoiWorkflow.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 doi_workflow = DoiWorkflow(workflow_id=telescopes[0].id)
 globals()[doi_workflow.dag_id] = doi_workflow.make_dag()

--- a/academic_observatory_workflows/dags/geonames_telescope.py
+++ b/academic_observatory_workflows/dags/geonames_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=GeonamesTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=GeonamesTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = GeonamesTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/geonames_telescope.py
+++ b/academic_observatory_workflows/dags/geonames_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.geonames_telescope import GeonamesTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = GeonamesTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=GeonamesTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = GeonamesTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/geonames_telescope.py
+++ b/academic_observatory_workflows/dags/geonames_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=GeonamesTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = GeonamesTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = GeonamesTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/grid_telescope.py
+++ b/academic_observatory_workflows/dags/grid_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=GridTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = GridTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = GridTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/grid_telescope.py
+++ b/academic_observatory_workflows/dags/grid_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.grid_telescope import GridTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = GridTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=GridTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = GridTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/grid_telescope.py
+++ b/academic_observatory_workflows/dags/grid_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=GridTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=GridTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = GridTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/open_citations_telescope.py
+++ b/academic_observatory_workflows/dags/open_citations_telescope.py
@@ -31,6 +31,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=OpenCitationsTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = OpenCitationsTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = OpenCitationsTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/open_citations_telescope.py
+++ b/academic_observatory_workflows/dags/open_citations_telescope.py
@@ -26,6 +26,11 @@ Saved to the BigQuery table: <project_id>.open_citations.open_citationsYYYYMMDD
 from academic_observatory_workflows.workflows.open_citations_telescope import (
     OpenCitationsTelescope,
 )
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = OpenCitationsTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=OpenCitationsTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = OpenCitationsTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/open_citations_telescope.py
+++ b/academic_observatory_workflows/dags/open_citations_telescope.py
@@ -30,7 +30,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=OpenCitationsTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=OpenCitationsTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = OpenCitationsTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/openalex_telescope.py
+++ b/academic_observatory_workflows/dags/openalex_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=OpenAlexTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = OpenAlexTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = OpenAlexTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/openalex_telescope.py
+++ b/academic_observatory_workflows/dags/openalex_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=OpenAlexTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=OpenAlexTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = OpenAlexTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/openalex_telescope.py
+++ b/academic_observatory_workflows/dags/openalex_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.openalex_telescope import OpenAlexTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = OpenAlexTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=OpenAlexTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = OpenAlexTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/orcid_telescope.py
+++ b/academic_observatory_workflows/dags/orcid_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=OrcidTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=OrcidTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = OrcidTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/orcid_telescope.py
+++ b/academic_observatory_workflows/dags/orcid_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.orcid_telescope import OrcidTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = OrcidTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=OrcidTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = OrcidTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/orcid_telescope.py
+++ b/academic_observatory_workflows/dags/orcid_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=OrcidTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = OrcidTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = OrcidTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/ror_telescope.py
+++ b/academic_observatory_workflows/dags/ror_telescope.py
@@ -23,6 +23,6 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=RorTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
-telescope = RorTelescope(workflow_id=telescopes[0].id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
+workflow = RorTelescope(workflow_id=workflows[0].id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/ror_telescope.py
+++ b/academic_observatory_workflows/dags/ror_telescope.py
@@ -22,7 +22,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=RorTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=RorTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 telescope = RorTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/ror_telescope.py
+++ b/academic_observatory_workflows/dags/ror_telescope.py
@@ -18,6 +18,11 @@
 # https://airflow.apache.org/docs/stable/faq.html
 
 from academic_observatory_workflows.workflows.ror_telescope import RorTelescope
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = RorTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=RorTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+telescope = RorTelescope(workflow_id=telescopes[0].id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/scopus_telescope.py
+++ b/academic_observatory_workflows/dags/scopus_telescope.py
@@ -25,12 +25,12 @@ from observatory.platform.utils.workflow_utils import make_dag_id
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=ScopusTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 dataset_type = api.get_dataset_type(type_id="scopus")
 
 # Create workflows for each organisation
-for telescope in telescopes:
-    dag_id = make_dag_id(ScopusTelescope.DAG_ID, telescope.organisation.name)
+for workflow in workflows:
+    dag_id = make_dag_id(ScopusTelescope.DAG_ID, workflow.organisation.name)
     airflow_conns = dataset_type.extra.get("airflow_connections")
     institution_ids = dataset_type.extra.get("institution_ids")
     view = dataset_type.extra.get("view")
@@ -47,14 +47,14 @@ for telescope in telescopes:
         AirflowVars.DATA_LOCATION,
     ]
 
-    telescope = ScopusTelescope(
+    workflow = ScopusTelescope(
         dag_id=dag_id,
         airflow_conns=airflow_conns,
         airflow_vars=airflow_vars,
         institution_ids=institution_ids,
         earliest_date=earliest_date,
         view=view,
-        workflow_id=telescope.id,
+        workflow_id=workflow.id,
     )
 
-    globals()[telescope.dag_id] = telescope.make_dag()
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/scopus_telescope.py
+++ b/academic_observatory_workflows/dags/scopus_telescope.py
@@ -26,19 +26,20 @@ from observatory.platform.utils.workflow_utils import make_dag_id
 api = make_observatory_api()
 telescope_type = api.get_telescope_type(type_id=ScopusTelescope.DAG_ID)
 telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+dataset_type = api.get_dataset_type(type_id="scopus")
 
 # Create workflows for each organisation
 for telescope in telescopes:
     dag_id = make_dag_id(ScopusTelescope.DAG_ID, telescope.organisation.name)
-    airflow_conns = telescope.extra.get("airflow_connections")
-    institution_ids = telescope.extra.get("institution_ids")
-    view = telescope.extra.get("view")
+    airflow_conns = dataset_type.extra.get("airflow_connections")
+    institution_ids = dataset_type.extra.get("institution_ids")
+    view = dataset_type.extra.get("view")
 
     if airflow_conns is None or institution_ids is None or view is None:
         raise Exception(f"airflow_conns: {airflow_conns} or institution_ids: {institution_ids} or view: {view} is None")
 
     # earliest_date is parsed into a datetime.date object by the Python API client
-    earliest_date_str = telescope.extra.get("earliest_date")
+    earliest_date_str = dataset_type.extra.get("earliest_date")
     earliest_date = pendulum.parse(earliest_date_str)
 
     airflow_vars = [
@@ -53,6 +54,7 @@ for telescope in telescopes:
         institution_ids=institution_ids,
         earliest_date=earliest_date,
         view=view,
+        workflow_id=telescope.id,
     )
 
     globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/scopus_telescope.py
+++ b/academic_observatory_workflows/dags/scopus_telescope.py
@@ -24,8 +24,8 @@ from observatory.platform.utils.api import make_observatory_api
 from observatory.platform.utils.workflow_utils import make_dag_id
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=ScopusTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=ScopusTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 dataset_type = api.get_dataset_type(type_id="scopus")
 
 # Create workflows for each organisation

--- a/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
@@ -36,10 +36,10 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=UnpaywallSnapshotTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
 # Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
-telescope = telescopes[0]
+workflow = workflows[0]
 
-telescope = UnpaywallSnapshotTelescope(workflow_id=telescope.id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflow = UnpaywallSnapshotTelescope(workflow_id=workflow.id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
@@ -31,6 +31,15 @@ Does not work with the following releases:
 from academic_observatory_workflows.workflows.unpaywall_snapshot_telescope import (
     UnpaywallSnapshotTelescope,
 )
+from observatory.platform.utils.api import make_observatory_api
 
-telescope = UnpaywallSnapshotTelescope()
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=UnpaywallSnapshotTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+
+# Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
+telescope = telescopes[0]
+
+telescope = UnpaywallSnapshotTelescope(workflow_id=telescope.id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
@@ -35,8 +35,8 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=UnpaywallSnapshotTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=UnpaywallSnapshotTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
 telescope = telescopes[0]

--- a/academic_observatory_workflows/dags/unpaywall_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_telescope.py
@@ -22,7 +22,16 @@ import pendulum
 from academic_observatory_workflows.workflows.unpaywall_telescope import (
     UnpaywallTelescope,
 )
+from observatory.platform.utils.api import make_observatory_api
+
+
+api = make_observatory_api()
+telescope_type = api.get_telescope_type(type_id=UnpaywallTelescope.DAG_ID)
+telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+
+# Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
+telescope = telescopes[0]
 
 start_date = pendulum.datetime(2021, 10, 18)  # Set this to the snapshot release date you want to base it off
-telescope = UnpaywallTelescope(start_date=start_date)
+telescope = UnpaywallTelescope(start_date=start_date, workflow_id=telescope.id)
 globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/unpaywall_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_telescope.py
@@ -26,8 +26,8 @@ from observatory.platform.utils.api import make_observatory_api
 
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=UnpaywallTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=UnpaywallTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
 telescope = telescopes[0]

--- a/academic_observatory_workflows/dags/unpaywall_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_telescope.py
@@ -27,11 +27,11 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=UnpaywallTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
 # Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
-telescope = telescopes[0]
+workflow = workflows[0]
 
 start_date = pendulum.datetime(2021, 10, 18)  # Set this to the snapshot release date you want to base it off
-telescope = UnpaywallTelescope(start_date=start_date, workflow_id=telescope.id)
-globals()[telescope.dag_id] = telescope.make_dag()
+workflow = UnpaywallTelescope(start_date=start_date, workflow_id=workflow.id)
+globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/web_of_science_telescope.py
+++ b/academic_observatory_workflows/dags/web_of_science_telescope.py
@@ -27,19 +27,19 @@ from observatory.platform.utils.workflow_utils import make_dag_id
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=WebOfScienceTelescope.DAG_ID)
-telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
 
 # Create workflows for each organisation
-for telescope in telescopes:
-    dag_id = make_dag_id(WebOfScienceTelescope.DAG_ID, telescope.organisation.name)
-    airflow_conns = telescope.extra.get("airflow_connections")
-    institution_ids = telescope.extra.get("institution_ids")
+for workflow in workflows:
+    dag_id = make_dag_id(WebOfScienceTelescope.DAG_ID, workflow.organisation.name)
+    airflow_conns = workflow.extra.get("airflow_connections")
+    institution_ids = workflow.extra.get("institution_ids")
 
     if airflow_conns is None or institution_ids is None:
         raise Exception(f"airflow_conns: {airflow_conns} or institution_ids: {institution_ids} is None")
 
     # earliest_date is parsed into a datetime.date object by the Python API client
-    earliest_date_str = telescope.extra.get("earliest_date")
+    earliest_date_str = workflow.extra.get("earliest_date")
     earliest_date = pendulum.parse(earliest_date_str)
 
     airflow_vars = [
@@ -47,13 +47,13 @@ for telescope in telescopes:
         AirflowVars.DATA_LOCATION,
     ]
 
-    telescope = WebOfScienceTelescope(
+    workflow = WebOfScienceTelescope(
         dag_id=dag_id,
         airflow_conns=airflow_conns,
         airflow_vars=airflow_vars,
         institution_ids=institution_ids,
         earliest_date=earliest_date,
-        workflow_id=telescope.id,
+        workflow_id=workflow.id,
     )
 
-    globals()[telescope.dag_id] = telescope.make_dag()
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/web_of_science_telescope.py
+++ b/academic_observatory_workflows/dags/web_of_science_telescope.py
@@ -53,6 +53,7 @@ for telescope in telescopes:
         airflow_vars=airflow_vars,
         institution_ids=institution_ids,
         earliest_date=earliest_date,
+        workflow_id=telescope.id,
     )
 
     globals()[telescope.dag_id] = telescope.make_dag()

--- a/academic_observatory_workflows/dags/web_of_science_telescope.py
+++ b/academic_observatory_workflows/dags/web_of_science_telescope.py
@@ -26,8 +26,8 @@ from observatory.platform.utils.api import make_observatory_api
 from observatory.platform.utils.workflow_utils import make_dag_id
 
 api = make_observatory_api()
-telescope_type = api.get_telescope_type(type_id=WebOfScienceTelescope.DAG_ID)
-telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+workflow_type = api.get_workflow_type(type_id=WebOfScienceTelescope.DAG_ID)
+telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
 
 # Create workflows for each organisation
 for telescope in telescopes:

--- a/academic_observatory_workflows/fixtures/unpaywall/daily-feed/changefile/changed_dois_with_versions_2021-07-01T080001.jsonl.gz
+++ b/academic_observatory_workflows/fixtures/unpaywall/daily-feed/changefile/changed_dois_with_versions_2021-07-01T080001.jsonl.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8e662a8e9de255abed1c9459f1a6f3e735a6a34fc1f1463554defc8f9d3e476
+size 1295

--- a/academic_observatory_workflows/fixtures/unpaywall/daily-feed/changefile/changed_dois_with_versions_2021-07-03T080001.jsonl.gz
+++ b/academic_observatory_workflows/fixtures/unpaywall/daily-feed/changefile/changed_dois_with_versions_2021-07-03T080001.jsonl.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8e662a8e9de255abed1c9459f1a6f3e735a6a34fc1f1463554defc8f9d3e476
+size 1295

--- a/academic_observatory_workflows/fixtures/unpaywall/daily-feed/changefiles.jinja2
+++ b/academic_observatory_workflows/fixtures/unpaywall/daily-feed/changefiles.jinja2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:60fd519b80f3fd36f4b3b74f8ae790680d2576c3ad2b586691984c26811bafed
-size 441
+oid sha256:6464a5616eb47050dd7f4081cd43368365a097a7af9db10098b006e9ba6a1038
+size 1277

--- a/academic_observatory_workflows/model.py
+++ b/academic_observatory_workflows/model.py
@@ -887,6 +887,7 @@ def bq_load_observatory_dataset(
     dataset_id_settings: str,
     release_date: DateTime,
     data_location: str,
+    project_id: int,
 ):
     """Load the fake Observatory Dataset in BigQuery.
 
@@ -896,6 +897,7 @@ def bq_load_observatory_dataset(
     :param dataset_id_settings: the dataset id for settings tables.
     :param release_date: the release date for the observatory dataset.
     :param data_location: the location of the BigQuery dataset.
+    :param project_id: api project id.
     :return: None.
     """
 
@@ -989,7 +991,13 @@ def bq_load_observatory_dataset(
             Table("orcid", False, dataset_id_all, [], "orcid", analysis_schema_path),
         ]
 
-        bq_load_tables(tables=tables, bucket_name=bucket_name, release_date=release_date, data_location=data_location)
+        bq_load_tables(
+            tables=tables,
+            bucket_name=bucket_name,
+            release_date=release_date,
+            data_location=data_location,
+            project_id=project_id,
+        )
 
 
 def aggregate_events(events: List[Event]) -> Tuple[List[Dict], List[Dict], List[Dict]]:

--- a/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
@@ -185,6 +185,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
         table_descriptions: Dict = None,
         catchup: bool = True,
         airflow_vars: List = None,
+        workflow_id: int = None,
     ):
 
         """Construct a CrossrefFundrefTelescope instance.
@@ -198,6 +199,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
         :param table_descriptions: a dictionary with table ids and corresponding table descriptions.
         :param catchup: whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
+        :param workflow_id: api workflow id.
         """
 
         if table_descriptions is None:
@@ -227,6 +229,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
             table_descriptions=table_descriptions,
             catchup=catchup,
             airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
         )
 
         # Create Gitlab pool to limit the number of connections to Gitlab, which is very quick to block requests if
@@ -245,6 +248,7 @@ class CrossrefFundrefTelescope(SnapshotTelescope):
         self.add_task(self.upload_transformed)
         self.add_task(self.bq_load)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
 
     def make_release(self, **kwargs) -> List[CrossrefFundrefRelease]:
         """Make release instances. The release is passed as an argument to the function (TelescopeFunction) that is

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -187,6 +187,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         airflow_conns: List = None,
         max_active_runs: int = 1,
         max_processes: int = os.cpu_count(),
+        workflow_id: int = None,
     ):
         """The Crossref Metadata telescope
 
@@ -203,6 +204,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         :param airflow_conns: list of airflow connection keys, for each connection it is checked if it exists in airflow
         :param max_active_runs: the maximum number of DAG runs that can be run at once.
         :param max_processes: the number of processes used with ProcessPoolExecutor to transform files in parallel.
+        :param workflow_id: api workflow id.
         """
 
         if table_descriptions is None:
@@ -235,6 +237,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
             max_active_runs=max_active_runs,
+            workflow_id=workflow_id,
         )
         self.max_processes = max_processes
 
@@ -247,6 +250,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         self.add_task(self.upload_transformed)
         self.add_task(self.bq_load)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
 
     def make_release(self, **kwargs) -> List[CrossrefMetadataRelease]:
         """Make release instances. The release is passed as an argument to the function (TelescopeFunction) that is

--- a/academic_observatory_workflows/workflows/geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/geonames_telescope.py
@@ -153,6 +153,7 @@ class GeonamesTelescope(SnapshotTelescope):
         table_descriptions: Dict = None,
         catchup: bool = False,
         airflow_vars: List = None,
+        workflow_id: int = None,
     ):
 
         """The Geonames telescope.
@@ -168,6 +169,7 @@ class GeonamesTelescope(SnapshotTelescope):
         :param table_descriptions: a dictionary with table ids and corresponding table descriptions.
         :param catchup:  whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
+        :param workflow_id: api workflow id.
         """
 
         if load_bigquery_table_kwargs is None:
@@ -200,6 +202,7 @@ class GeonamesTelescope(SnapshotTelescope):
             table_descriptions=table_descriptions,
             catchup=catchup,
             airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
         )
         self.add_setup_task(self.check_dependencies)
         self.add_setup_task(self.fetch_release_date)
@@ -210,6 +213,7 @@ class GeonamesTelescope(SnapshotTelescope):
         self.add_task(self.upload_transformed)
         self.add_task(self.bq_load)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
 
     def make_release(self, **kwargs) -> List[GeonamesRelease]:
         """Make release instances. The release is passed as an argument to the function (TelescopeFunction) that is

--- a/academic_observatory_workflows/workflows/grid_telescope.py
+++ b/academic_observatory_workflows/workflows/grid_telescope.py
@@ -220,6 +220,7 @@ class GridTelescope(SnapshotTelescope):
         dataset_description: str = "Datasets provided by Digital Science: https://www.digital-science.com/",
         catchup: bool = True,
         airflow_vars: List = None,
+        workflow_id: int = None,
     ):
         """Construct a GridTelescope instance.
 
@@ -232,6 +233,7 @@ class GridTelescope(SnapshotTelescope):
         :param dataset_description: description for the BigQuery dataset.
         :param catchup: whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
+        :param workflow_id: api workflow id.
         """
 
         if airflow_vars is None:
@@ -252,6 +254,7 @@ class GridTelescope(SnapshotTelescope):
             dataset_description=dataset_description,
             catchup=catchup,
             airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
         )
 
         self.add_setup_task_chain([self.check_dependencies, self.list_releases])
@@ -264,6 +267,7 @@ class GridTelescope(SnapshotTelescope):
                 self.upload_transformed,
                 self.bq_load,
                 self.cleanup,
+                self.add_new_dataset_releases,
             ]
         )
 

--- a/academic_observatory_workflows/workflows/open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/open_citations_telescope.py
@@ -98,6 +98,7 @@ class OpenCitationsTelescope(SnapshotTelescope):
         table_descriptions: Dict = None,
         catchup: bool = False,
         airflow_vars: List = None,
+        workflow_id: int = None,
     ):
         """
         :param dag_id: the id of the DAG.
@@ -110,6 +111,7 @@ class OpenCitationsTelescope(SnapshotTelescope):
         :param table_descriptions: a dictionary with table ids and corresponding table descriptions.
         :param catchup:  whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow.
+        :param workflow_id: api workflow id.
         """
 
         load_bigquery_table_kwargs = {
@@ -118,7 +120,7 @@ class OpenCitationsTelescope(SnapshotTelescope):
             "csv_skip_leading_rows": 1,
             "csv_allow_quoted_newlines": True,
             "write_disposition": bigquery.WriteDisposition.WRITE_APPEND,
-            "ignore_unknown_values": True
+            "ignore_unknown_values": True,
         }
 
         if table_descriptions is None:
@@ -146,6 +148,7 @@ class OpenCitationsTelescope(SnapshotTelescope):
             table_descriptions=table_descriptions,
             catchup=catchup,
             airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
         )
 
         self.add_setup_task(self.check_dependencies)
@@ -156,6 +159,7 @@ class OpenCitationsTelescope(SnapshotTelescope):
         self.add_task(self.upload_transformed)
         self.add_task(self.bq_load)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
 
     def _list_releases(
         self,

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -501,7 +501,7 @@ def write_modified_record_blobs(
                     last_modified_date = pendulum.parse(elements[3])
 
                     # skip records that are too new, not included in this release
-                    if last_modified_date > end_date:
+                    if last_modified_date >= end_date:
                         continue
                     # use records between start date and end date
                     elif last_modified_date >= start_date:

--- a/academic_observatory_workflows/workflows/ror_telescope.py
+++ b/academic_observatory_workflows/workflows/ror_telescope.py
@@ -139,6 +139,7 @@ class RorTelescope(SnapshotTelescope):
         dataset_description: str = "",
         catchup: bool = True,
         airflow_vars: List = None,
+        workflow_id: int = None,
     ):
         """Construct a RorTelescope instance.
 
@@ -152,6 +153,7 @@ class RorTelescope(SnapshotTelescope):
         :param dataset_description: description for the BigQuery dataset.
         :param catchup: whether to catchup the DAG or not.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
+        :param workflow_id: api workflow id.
         """
 
         if airflow_vars is None:
@@ -177,6 +179,7 @@ class RorTelescope(SnapshotTelescope):
             dataset_description=dataset_description,
             catchup=catchup,
             airflow_vars=airflow_vars,
+            workflow_id=workflow_id,
         )
 
         self.add_setup_task_chain([self.check_dependencies, self.list_releases])
@@ -189,6 +192,7 @@ class RorTelescope(SnapshotTelescope):
                 self.upload_transformed,
                 self.bq_load,
                 self.cleanup,
+                self.add_new_dataset_releases,
             ]
         )
 

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -41,7 +41,7 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
@@ -108,13 +108,13 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -134,7 +134,7 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
             name="Crossref Events Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -102,9 +102,9 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -134,7 +134,7 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
             name="Crossref Events Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -37,6 +37,20 @@ from observatory.platform.utils.test_utils import (
 )
 from observatory.platform.utils.url_utils import get_user_agent
 from observatory.platform.utils.workflow_utils import blob_name, create_date_table_id
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestCrossrefEventsTelescope(ObservatoryTestCase):
@@ -51,15 +65,15 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
-        self.first_execution_date = pendulum.datetime(year=2018, month=5, day=14)
+        self.first_execution_date = pendulum.datetime(year=2018, month=5, day=21)
         self.first_cassette = test_fixtures_folder("crossref_events", "crossref_events1.yaml")
 
-        self.second_execution_date = pendulum.datetime(year=2018, month=5, day=20)
+        self.second_execution_date = pendulum.datetime(year=2018, month=5, day=28)
         self.second_cassette = test_fixtures_folder("crossref_events", "crossref_events2.yaml")
 
         # additional tests setup
         self.start_date = pendulum.datetime(2021, 5, 6)
-        self.end_date = pendulum.datetime(2021, 5, 12)
+        self.end_date = pendulum.datetime(2021, 5, 13)
         self.release = CrossrefEventsRelease(
             CrossrefEventsTelescope.DAG_ID,
             self.start_date,
@@ -69,6 +83,66 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
             max_threads=21,
             max_processes=1,
         )
+
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Crossref Events Telescope"
+        telescope_type = TelescopeType(name=name, type_id=CrossrefEventsTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=CrossrefEventsTelescope.DAG_ID,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Crossref Events Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
 
     def test_dag_structure(self):
         """Test that the Crossref Events DAG has the correct structure.
@@ -86,7 +160,8 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
                 "bq_load_partition": ["bq_delete_old"],
                 "bq_delete_old": ["bq_append_new"],
                 "bq_append_new": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -96,7 +171,11 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(
                 module_file_path("academic_observatory_workflows.dags"), "crossref_events_telescope.py"
             )
@@ -107,31 +186,31 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         :return: None.
         """
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
-        telescope = CrossrefEventsTelescope(dataset_id=dataset_id)
+        telescope = CrossrefEventsTelescope(dataset_id=dataset_id, workflow_id=1)
         telescope.max_threads = 1
         telescope.max_processes = 1
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create(task_logging=True):
+            self.setup_connections(env)
+            self.setup_api()
             # first run
             with env.create_dag_run(dag, self.first_execution_date) as dag_run:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
                 start_date, end_date, first_release = telescope.get_release_info(
-                    execution_date=self.first_execution_date,
                     dag=dag,
-                    dag_run=dag_run,
-                    next_execution_date=pendulum.datetime(2018, 5, 20),
+                    data_interval_end=pendulum.datetime(2018, 5, 20),
                 )
 
                 self.assertEqual(start_date, dag.default_args["start_date"])
-                self.assertEqual(end_date, pendulum.today("UTC") - timedelta(days=1))
+                self.assertEqual(pendulum.instance(end_date), pendulum.datetime(2018, 5, 20))
                 self.assertTrue(first_release)
 
                 # use release info for other tasks
@@ -146,7 +225,8 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
                 )
 
                 # Test download task
-                with vcr.use_cassette(self.first_cassette):
+                vcr_ = vcr.VCR(ignore_localhost=True)
+                with vcr_.use_cassette(self.first_cassette):
                     env.run_task(telescope.download.__name__)
                 self.assertEqual(6, len(release.download_files))
                 for file in release.download_files:
@@ -178,12 +258,12 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
 
                 # Test that load partition task is skipped for the first release
                 ti = env.run_task(telescope.bq_load_partition.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test delete old task is skipped for the first release
                 with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
                     ti = env.run_task(telescope.bq_delete_old.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test append new creates table
                 env.run_task(telescope.bq_append_new.__name__)
@@ -201,20 +281,26 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
             # second run
             with env.create_dag_run(dag, self.second_execution_date) as dag_run:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
 
                 start_date, end_date, first_release = telescope.get_release_info(
-                    execution_date=self.second_execution_date,
                     dag=dag,
-                    dag_run=dag_run,
-                    next_execution_date=pendulum.datetime(2018, 5, 27),
+                    data_interval_end=pendulum.datetime(2018, 5, 27),
                 )
 
-                self.assertEqual(release.end_date + timedelta(days=1), start_date)
-                self.assertEqual(pendulum.today("UTC") - timedelta(days=1), end_date)
+                self.assertEqual(release.end_date, start_date)
+                self.assertEqual(pendulum.datetime(2018, 5, 27), end_date)
                 self.assertFalse(first_release)
 
                 # use release info for other tasks
@@ -229,7 +315,7 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
                 )
 
                 # Test download task
-                with vcr.use_cassette(self.second_cassette):
+                with vcr_.use_cassette(self.second_cassette):
                     env.run_task(telescope.download.__name__)
 
                 self.assertEqual(20, len(release.download_files))
@@ -294,6 +380,14 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 2)
 
     def test_urls(self):
         """Test the urls property of release

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -42,7 +42,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -97,8 +97,8 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Crossref Events Telescope"
-        telescope_type = TelescopeType(name=name, type_id=CrossrefEventsTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=CrossrefEventsTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -110,7 +110,7 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -93,9 +93,9 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -46,7 +46,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -88,8 +88,8 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Crossref Fundref Telescope"
-        telescope_type = TelescopeType(name=name, type_id=CrossrefFundrefTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=CrossrefFundrefTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -101,7 +101,7 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -125,7 +125,7 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
             name="Crossref Fundref Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -41,6 +41,20 @@ from observatory.platform.utils.workflow_utils import (
     bigquery_sharded_table_id,
     blob_name,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestCrossrefFundrefTelescope(ObservatoryTestCase):
@@ -61,6 +75,66 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
         self.extract_hash = "559aa89d41a85ff84d705084c1caeb8d"
         self.transform_hash = "632b453a"
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Crossref Fundref Telescope"
+        telescope_type = TelescopeType(name=name, type_id=CrossrefFundrefTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=CrossrefFundrefTelescope.DAG_ID,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Crossref Fundref Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the CrossrefFundref DAG has the correct structure.
 
@@ -79,7 +153,8 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
                     "transform": ["upload_transformed"],
                     "upload_transformed": ["bq_load"],
                     "bq_load": ["cleanup"],
-                    "cleanup": [],
+                    "cleanup": ["add_new_dataset_releases"],
+                    "add_new_dataset_releases": [],
                 },
                 dag,
             )
@@ -90,7 +165,11 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(
                 module_file_path("academic_observatory_workflows.dags"), "crossref_fundref_telescope.py"
             )
@@ -103,14 +182,16 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
         """
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             # Setup Telescope inside env, so pool can be created
             execution_date = pendulum.datetime(year=2021, month=6, day=1)
-            telescope = CrossrefFundrefTelescope(dataset_id=dataset_id)
+            telescope = CrossrefFundrefTelescope(dataset_id=dataset_id, workflow_id=1)
             dag = telescope.make_dag()
 
             with env.create_dag_run(dag, execution_date):
@@ -187,6 +268,14 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
 
     def test_list_releases(self):
         """Test that list releases returns a list with dictionaries of release info.

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -45,7 +45,7 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
@@ -99,13 +99,13 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -125,7 +125,7 @@ class TestCrossrefFundrefTelescope(ObservatoryTestCase):
             name="Crossref Fundref Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -139,7 +139,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
             name="Crossref Metadata Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -42,6 +42,20 @@ from observatory.platform.utils.test_utils import (
     module_file_path,
 )
 from observatory.platform.utils.workflow_utils import blob_name
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestCrossrefMetadataTelescope(ObservatoryTestCase):
@@ -76,6 +90,66 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         # release used for tests outside observatory test environment
         self.release = CrossrefMetadataRelease("crossref_metadata", datetime(2020, 1, 1))
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Crossref Metadata Telescope"
+        telescope_type = TelescopeType(name=name, type_id=CrossrefMetadataTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id=CrossrefMetadataTelescope.DAG_ID,
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Crossref Metadata Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the Crossref Metadata DAG has the correct structure.
 
@@ -93,7 +167,8 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
                 "transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load"],
                 "bq_load": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -104,7 +179,11 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(
                 module_file_path("academic_observatory_workflows.dags"), "crossref_metadata_telescope.py"
             )
@@ -117,16 +196,18 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         """
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
         execution_date = pendulum.datetime(year=2022, month=1, day=1)
-        telescope = CrossrefMetadataTelescope(dataset_id=dataset_id)
+        telescope = CrossrefMetadataTelescope(dataset_id=dataset_id, workflow_id=1)
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             with env.create_dag_run(dag, execution_date):
                 # Add Crossref Metadata connection
                 env.add_connection(Connection(conn_id=AirflowConns.CROSSREF, uri="mysql://:crossref-token@"))
@@ -192,6 +273,14 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
 
     @patch("academic_observatory_workflows.workflows.crossref_metadata_telescope.BaseHook.get_connection")
     def test_download(self, mock_conn):

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -108,9 +108,9 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -47,7 +47,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -103,8 +103,8 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Crossref Metadata Telescope"
-        telescope_type = TelescopeType(name=name, type_id=CrossrefMetadataTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=CrossrefMetadataTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -116,7 +116,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -46,10 +46,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -114,13 +113,13 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -140,7 +139,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
             name="Crossref Metadata Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -163,7 +163,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
             name="Example Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -50,7 +50,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -126,8 +126,8 @@ class TestDoiWorkflow(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Doi Workflow"
-        telescope_type = TelescopeType(name=name, type_id="doi")
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id="doi")
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -139,7 +139,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -49,7 +49,7 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
@@ -137,13 +137,13 @@ class TestDoiWorkflow(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -163,7 +163,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
             name="Example Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)
@@ -272,9 +272,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(
-            self.project_id, self.data_location, api_host=self.host, api_port=self.port
-        )
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         with env.create():
             self.setup_connections(env)
             self.setup_api()

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -46,7 +46,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -92,8 +92,8 @@ class TestGeonamesTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Geonames Telescope"
-        telescope_type = TelescopeType(name=name, type_id=GeonamesTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=GeonamesTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -105,7 +105,7 @@ class TestGeonamesTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -128,7 +128,7 @@ class TestGeonamesTelescope(ObservatoryTestCase):
             name="Geonames Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -97,9 +97,9 @@ class TestGeonamesTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -39,6 +39,22 @@ from observatory.platform.utils.workflow_utils import (
     blob_name,
     workflow_path,
 )
+from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
+from observatory.platform.utils.workflow_utils import blob_name
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class MockResponse:
@@ -63,6 +79,66 @@ class TestGeonamesTelescope(ObservatoryTestCase):
         self.fetch_release_date_path = test_fixtures_folder("geonames", "fetch_release_date.yaml")
         self.list_releases_path = test_fixtures_folder("geonames", "list_releases.yaml")
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Geonames Telescope"
+        telescope_type = TelescopeType(name=name, type_id=GeonamesTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="geonames",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Geonames Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the Geonames DAG has the correct structure.
 
@@ -80,7 +156,8 @@ class TestGeonamesTelescope(ObservatoryTestCase):
                 "transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load"],
                 "bq_load": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -91,7 +168,11 @@ class TestGeonamesTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "geonames_telescope.py")
             self.assert_dag_load("geonames", dag_file)
 
@@ -132,16 +213,18 @@ class TestGeonamesTelescope(ObservatoryTestCase):
         """
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
         execution_date = pendulum.datetime(year=2020, month=11, day=1)
-        telescope = GeonamesTelescope(dataset_id=dataset_id)
+        telescope = GeonamesTelescope(dataset_id=dataset_id, workflow_id=1)
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             with env.create_dag_run(dag, execution_date):
                 # Release settings
                 release_date = pendulum.datetime(year=2021, month=3, day=5, hour=1, minute=34, second=32)
@@ -210,3 +293,11 @@ class TestGeonamesTelescope(ObservatoryTestCase):
                 # Test that all telescope data deleted
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -45,10 +45,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -103,13 +102,13 @@ class TestGeonamesTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -129,7 +128,7 @@ class TestGeonamesTelescope(ObservatoryTestCase):
             name="Geonames Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -410,7 +410,7 @@ class TestGridTelescopeDag(ObservatoryTestCase):
             name="GRID Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -44,10 +44,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -385,13 +384,13 @@ class TestGridTelescopeDag(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -411,7 +410,7 @@ class TestGridTelescopeDag(ObservatoryTestCase):
             name="GRID Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -45,7 +45,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -374,8 +374,8 @@ class TestGridTelescopeDag(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "GRID Telescope"
-        telescope_type = TelescopeType(name=name, type_id=GridTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=GridTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -387,7 +387,7 @@ class TestGridTelescopeDag(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -379,9 +379,9 @@ class TestGridTelescopeDag(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -39,6 +39,21 @@ from observatory.platform.utils.test_utils import (
     module_file_path,
 )
 from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
+from observatory.platform.utils.workflow_utils import blob_name
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class MockResponse:
@@ -346,11 +361,71 @@ class TestGridTelescopeDag(ObservatoryTestCase):
         #     f"http://{self.httpserver.host}:{self.httpserver.port}" + "/v2/articles/{article_id}/files"
         # )
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "GRID Telescope"
+        telescope_type = TelescopeType(name=name, type_id=GridTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="grid",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="GRID Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def __del__(self):
         self.httpserver.stop()
 
     def setup_observatory_environment(self):
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         self.dataset_id = env.add_dataset()
         return env
 
@@ -371,7 +446,8 @@ class TestGridTelescopeDag(ObservatoryTestCase):
                 "transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load"],
                 "bq_load": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -382,8 +458,11 @@ class TestGridTelescopeDag(ObservatoryTestCase):
         :return: None
         """
 
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "grid_telescope.py")
             self.assert_dag_load("grid", dag_file)
 
@@ -392,12 +471,14 @@ class TestGridTelescopeDag(ObservatoryTestCase):
         """Test running the telescope. Functional test."""
 
         env = self.setup_observatory_environment()
-        telescope = GridTelescope(dag_id="grid", dataset_id=self.dataset_id)
+        telescope = GridTelescope(dag_id="grid", dataset_id=self.dataset_id, workflow_id=1)
         dag = telescope.make_dag()
         execution_date = pendulum.datetime(year=2015, month=9, day=22)
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             with env.create_dag_run(dag, execution_date):
                 with patch.object(
                     GridTelescope,
@@ -486,3 +567,11 @@ class TestGridTelescopeDag(ObservatoryTestCase):
                         )
                         env.run_task(telescope.cleanup.__name__)
                         self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                        # add_dataset_release_task
+                        dataset_releases = get_dataset_releases(dataset_id=1)
+                        self.assertEqual(len(dataset_releases), 0)
+                        ti = env.run_task("add_new_dataset_releases")
+                        self.assertEqual(ti.state, State.SUCCESS)
+                        dataset_releases = get_dataset_releases(dataset_id=1)
+                        self.assertEqual(len(dataset_releases), 1)

--- a/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
@@ -44,10 +44,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -90,13 +89,13 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -116,7 +115,7 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
             name="Open Citations Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
@@ -115,7 +115,7 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
             name="Open Citations Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
@@ -45,7 +45,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -79,8 +79,8 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Open Citations Telescope"
-        telescope_type = TelescopeType(name=name, type_id=OpenCitationsTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OpenCitationsTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -92,7 +92,7 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
@@ -39,6 +39,21 @@ from observatory.platform.utils.workflow_utils import (
     bigquery_sharded_table_id,
     blob_name,
 )
+from observatory.platform.utils.workflow_utils import blob_name
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestOpenCitationsTelescope(ObservatoryTestCase):
@@ -50,6 +65,66 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
         self.fixture_dir = test_fixtures_folder("open_citations")
         self.release_list_file = "list_open_citation_releases.json"
         self.version_1_file = "1.json"
+
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Open Citations Telescope"
+        telescope_type = TelescopeType(name=name, type_id=OpenCitationsTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="open_citations",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Open Citations Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
 
     def test_ctor(self):
         table_descriptions = {"open_citations": "Custom description"}
@@ -176,7 +251,8 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
                 "extract": ["upload_transformed"],
                 "upload_transformed": ["bq_load"],
                 "bq_load": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
@@ -187,7 +263,11 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(
                 module_file_path("academic_observatory_workflows.dags"), "open_citations_telescope.py"
             )
@@ -197,12 +277,14 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
         """Test the OpenCitationsTelescope telescope end to end."""
 
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             execution_date = pendulum.datetime(year=2018, month=11, day=12)
-            telescope = OpenCitationsTelescope(dataset_id=dataset_id)
+            telescope = OpenCitationsTelescope(dataset_id=dataset_id, workflow_id=1)
             dag = telescope.make_dag()
 
             with env.create_dag_run(dag, execution_date):
@@ -349,3 +431,11 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
                     env.run_task(telescope.cleanup.__name__)
                     self.assertEqual(ti.state, State.SUCCESS)
                     self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                    # add_dataset_release_task
+                    dataset_releases = get_dataset_releases(dataset_id=1)
+                    self.assertEqual(len(dataset_releases), 0)
+                    ti = env.run_task("add_new_dataset_releases")
+                    self.assertEqual(ti.state, State.SUCCESS)
+                    dataset_releases = get_dataset_releases(dataset_id=1)
+                    self.assertEqual(len(dataset_releases), 1)

--- a/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
@@ -84,9 +84,9 @@ class TestOpenCitationsTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -18,6 +18,7 @@ import gzip
 import io
 import json
 import os
+import datetime
 from datetime import timedelta
 from subprocess import Popen
 from unittest.mock import Mock, call, patch
@@ -45,6 +46,21 @@ from academic_observatory_workflows.workflows.openalex_telescope import (
     transform_file,
     transform_object,
 )
+from observatory.platform.utils.workflow_utils import blob_name
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestOpenAlexTelescope(ObservatoryTestCase):
@@ -113,6 +129,66 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             "manifest_transform_hash": "50e2eff06007a32c4394df8df7f5e907",
         }
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "OpenAlex Telescope"
+        telescope_type = TelescopeType(name=name, type_id=OpenAlexTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="openalex",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="OpenAlex Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the OpenAlex DAG has the correct structure.
         :return: None
@@ -130,36 +206,49 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 "bq_load_partition": ["bq_delete_old"],
                 "bq_delete_old": ["bq_append_new"],
                 "bq_append_new": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
 
-    def test_dag_load(self):
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_load(self, m_makeapi):
         """Test that the OpenAlex DAG can be loaded from a DAG bag.
         :return: None
         """
 
-        with ObservatoryEnvironment().create():
+        m_makeapi.return_value = self.api
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "openalex_telescope.py")
             self.assert_dag_load("openalex", dag_file)
 
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.aws_to_google_cloud_storage_transfer")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.boto3.client")
-    def test_telescope(self, mock_client, mock_transfer):
+    def test_telescope(self, mock_client, mock_transfer, m_makeapi):
         """Test the OpenAlex telescope end to end.
         :return: None.
         """
+
+        m_makeapi.return_value = self.api
+
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
-        telescope = OpenAlexTelescope(dataset_id=dataset_id)
+        telescope = OpenAlexTelescope(dataset_id=dataset_id, workflow_id=1)
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_api()
+
             # Add connection
             conn = Connection(
                 conn_id=OpenAlexTelescope.AIRFLOW_CONN_AWS, uri="aws://UWLA41aAhdja:AJLD91saAJSKAL0AjAhkaka@"
@@ -171,12 +260,11 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
                 start_date, end_date, first_release = telescope.get_release_info(
-                    next_execution_date=pendulum.today("UTC"),
                     dag=dag,
-                    dag_run=dag_run,
+                    data_interval_end=datetime.datetime(2021, 12, 26),
                 )
                 self.assertEqual(dag.default_args["start_date"], start_date)
-                self.assertEqual(pendulum.today("UTC") - timedelta(days=1), end_date)
+                self.assertEqual(pendulum.datetime(2021, 12, 26), end_date)
                 self.assertTrue(first_release)
 
                 # Use release info for other tasks
@@ -199,6 +287,8 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
                 # Test write transfer manifest task
                 env.run_task(telescope.write_transfer_manifest.__name__)
+                print(release.transfer_manifest_path_download)
+                print(run["manifest_download_hash"])
                 self.assert_file_integrity(
                     release.transfer_manifest_path_download, run["manifest_download_hash"], "md5"
                 )
@@ -289,12 +379,12 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
                 # Test that load partition task is skipped for the first release
                 ti = env.run_task(telescope.bq_load_partition.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test delete old task is skipped for the first release
                 with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
                     ti = env.run_task(telescope.bq_delete_old.__name__)
-                self.assertEqual(ti.state, "skipped")
+                self.assertEqual(ti.state, State.SUCCESS)
 
                 # Test append new creates table
                 env.run_task(telescope.bq_append_new.__name__)
@@ -312,17 +402,24 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+
             run = self.second_run
             with env.create_dag_run(dag, run["execution_date"]) as dag_run:
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
                 start_date, end_date, first_release = telescope.get_release_info(
-                    next_execution_date=pendulum.today("UTC"),
                     dag=dag,
-                    dag_run=dag_run,
+                    data_interval_end=datetime.datetime(2022, 1, 30),
                 )
-                self.assertEqual(release.end_date + timedelta(days=1), start_date)
-                self.assertEqual(pendulum.today("UTC") - timedelta(days=1), end_date)
+                self.assertEqual(release.end_date, start_date)
+                self.assertEqual(pendulum.datetime(2022, 1, 30), end_date)
                 self.assertFalse(first_release)
 
                 # Use release info for other tasks
@@ -463,6 +560,14 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 )
                 env.run_task(telescope.cleanup.__name__)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 2)
 
     @patch("academic_observatory_workflows.workflows.openalex_telescope.boto3.client")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.get_aws_conn_info")

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -52,7 +52,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -142,8 +142,8 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "OpenAlex Telescope"
-        telescope_type = TelescopeType(name=name, type_id=OpenAlexTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OpenAlexTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -155,7 +155,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -147,9 +147,9 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -51,10 +51,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -153,13 +152,13 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -179,7 +178,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             name="OpenAlex Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -178,7 +178,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             name="OpenAlex Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -50,7 +50,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -104,8 +104,8 @@ class TestOrcidTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "ORCID Telescope"
-        telescope_type = TelescopeType(name=name, type_id=OrcidTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=OrcidTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -117,7 +117,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -140,7 +140,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
             name="ORCID Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -49,10 +49,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -115,13 +114,13 @@ class TestOrcidTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -141,7 +140,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
             name="ORCID Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -109,9 +109,9 @@ class TestOrcidTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -42,10 +42,9 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -116,13 +115,13 @@ class TestRorTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -142,7 +141,7 @@ class TestRorTelescope(ObservatoryTestCase):
             name="RoR Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -141,7 +141,7 @@ class TestRorTelescope(ObservatoryTestCase):
             name="RoR Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -38,6 +38,20 @@ from observatory.platform.utils.test_utils import (
 from observatory.platform.utils.workflow_utils import (
     blob_name,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+from airflow.utils.state import State
 
 
 class TestRorTelescope(ObservatoryTestCase):
@@ -78,6 +92,66 @@ class TestRorTelescope(ObservatoryTestCase):
         }
         self.release = RorRelease("ror", pendulum.datetime(2021, 1, 1), "https://myurl")
 
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
+
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "RoR Telescope"
+        telescope_type = TelescopeType(name=name, type_id=RorTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+            type_id="ror",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="RoR Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
     def test_dag_structure(self):
         """Test that the ROR DAG has the correct structure.
 
@@ -95,36 +169,49 @@ class TestRorTelescope(ObservatoryTestCase):
                 "transform": ["upload_transformed"],
                 "upload_transformed": ["bq_load"],
                 "bq_load": ["cleanup"],
-                "cleanup": [],
+                "cleanup": ["add_new_dataset_releases"],
+                "add_new_dataset_releases": [],
             },
             dag,
         )
 
-    def test_dag_load(self):
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_load(self, m_makeapi):
         """Test that the ROR DAG can be loaded from a DAG bag.
 
         :return: None
         """
-        with ObservatoryEnvironment().create():
+
+        m_makeapi.return_value = self.api
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "ror_telescope.py")
             self.assert_dag_load("ror", dag_file)
 
-    def test_telescope(self):
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_telescope(self, m_makeapi):
         """Test the ROR telescope end to end.
 
         :return: None.
         """
+
+        m_makeapi.return_value = self.api
+
         # Setup Observatory environment
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         dataset_id = env.add_dataset()
 
         # Setup Telescope
         execution_date = pendulum.datetime(year=2021, month=9, day=19)
-        telescope = RorTelescope(dataset_id=dataset_id)
+        telescope = RorTelescope(dataset_id=dataset_id, workflow_id=1)
         dag = telescope.make_dag()
 
         # Create the Observatory environment and run tests
         with env.create():
+            self.setup_api()
             with env.create_dag_run(dag, execution_date):
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
@@ -220,6 +307,14 @@ class TestRorTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 for i, release in enumerate(releases):
                     self.assert_cleanup(download_folders[i], extract_folders[i], transform_folders[i])
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 2)
 
     @patch("academic_observatory_workflows.workflows.ror_telescope.list_ror_records")
     def test_list_releases(self, mock_list_records):

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -43,7 +43,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -105,8 +105,8 @@ class TestRorTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "RoR Telescope"
-        telescope_type = TelescopeType(name=name, type_id=RorTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=RorTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -118,7 +118,7 @@ class TestRorTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -110,9 +110,9 @@ class TestRorTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
@@ -715,7 +715,7 @@ class TestScopusTelescope(ObservatoryTestCase):
     def get_telescope(self, dataset_id):
         api = make_observatory_api()
         workflow_type = api.get_workflow_type(type_id=ScopusTelescope.DAG_ID)
-        telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+        telescopes = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
         self.assertEqual(len(telescopes), 1)
         dataset_type = api.get_dataset_type(type_id="scopus")
 

--- a/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
@@ -56,6 +56,22 @@ from observatory.platform.utils.workflow_utils import (
     build_schedule,
     make_dag_id,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
 
 
 class TestScopusUtility(unittest.TestCase):
@@ -630,6 +646,11 @@ class TestScopusTelescope(ObservatoryTestCase):
             self.results_str = f.read()
         self.results_len = 1
 
+        # API environment
+        configuration = Configuration(host=f"http://{self.host}:{self.api_port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+
     def setup_connections(self, env):
         # Add Observatory API connection
         conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.api_port}")
@@ -639,52 +660,71 @@ class TestScopusTelescope(ObservatoryTestCase):
         conn = Connection(conn_id=self.conn_id, uri=f"http://login:password@localhost")
         env.add_connection(conn)
 
-    def setup_api(self, env, extra=None):
+    def setup_api(self, extra=None):
         dt = pendulum.now("UTC")
+
+        name = "Scopus Telescope"
+        telescope_type = TelescopeType(name=name, type_id=ScopusTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+            type_id="partitioned",
+            name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
 
         if extra is None:
             extra = {
                 "airflow_connections": [self.conn_id],
-                "institution_ids": ["123"],
                 "earliest_date": self.earliest_date.isoformat(),
+                "institution_ids": ["123"],
                 "view": "STANDARD",
             }
 
-        name = "Scopus Telescope"
-        telescope_type = orm.TelescopeType(name=name, type_id=ScopusTelescope.DAG_ID, created=dt, modified=dt)
-        env.api_session.add(telescope_type)
-
-        organisation = orm.Organisation(
-            name=self.org_name,
-            created=dt,
-            modified=dt,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
-        )
-
-        env.api_session.add(organisation)
-        telescope = orm.Telescope(
-            name=name,
-            telescope_type=telescope_type,
-            organisation=organisation,
-            modified=dt,
-            created=dt,
+        dataset_type = DatasetType(
+            type_id="scopus",
+            name="scopus",
             extra=extra,
+            table_type=TableType(id=1),
         )
-        env.api_session.add(telescope)
-        env.api_session.commit()
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(
+            name="Scopus Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Telescope(id=1),
+            dataset_type=DatasetType(id=1),
+        )
+        self.api.put_dataset(dataset)
 
     def get_telescope(self, dataset_id):
         api = make_observatory_api()
         telescope_type = api.get_telescope_type(type_id=ScopusTelescope.DAG_ID)
         telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
         self.assertEqual(len(telescopes), 1)
+        dataset_type = api.get_dataset_type(type_id="scopus")
 
         dag_id = make_dag_id(ScopusTelescope.DAG_ID, telescopes[0].organisation.name)
-        airflow_conns = telescopes[0].extra.get("airflow_connections")
-        institution_ids = telescopes[0].extra.get("institution_ids")
-        earliest_date_str = telescopes[0].extra.get("earliest_date")
+        airflow_conns = dataset_type.extra.get("airflow_connections")
+        institution_ids = dataset_type.extra.get("institution_ids")
+        earliest_date_str = dataset_type.extra.get("earliest_date")
         earliest_date = pendulum.parse(earliest_date_str)
 
         airflow_vars = [
@@ -699,6 +739,7 @@ class TestScopusTelescope(ObservatoryTestCase):
             airflow_vars=airflow_vars,
             institution_ids=institution_ids,
             earliest_date=earliest_date,
+            workflow_id=1,
         )
 
         return telescope
@@ -726,50 +767,61 @@ class TestScopusTelescope(ObservatoryTestCase):
             earliest_date=pendulum.now("UTC"),
         )
 
-    def test_dag_structure(self):
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_structure(self, m_makeapi):
         """Test that the ScopusTelescope DAG has the correct structure.
 
         :return: None
         """
-        dag = ScopusTelescope(
-            dag_id="dag",
-            airflow_conns=["conn"],
-            airflow_vars=[],
-            institution_ids=["10"],
-            earliest_date=pendulum.now("UTC"),
-            view="standard",
-        ).make_dag()
-        self.assert_dag_structure(
-            {
-                "check_dependencies": ["download"],
-                "download": ["upload_downloaded"],
-                "upload_downloaded": ["transform"],
-                "transform": ["upload_transformed"],
-                "upload_transformed": ["bq_load"],
-                "bq_load": ["cleanup"],
-                "cleanup": [],
-            },
-            dag,
-        )
 
-    def test_dag_load(self):
+        m_makeapi.return_value = self.api
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
+            dag = ScopusTelescope(
+                dag_id="dag",
+                airflow_conns=["conn"],
+                airflow_vars=[],
+                institution_ids=["10"],
+                earliest_date=pendulum.now("UTC"),
+                view="standard",
+            ).make_dag()
+            self.assert_dag_structure(
+                {
+                    "check_dependencies": ["download"],
+                    "download": ["upload_downloaded"],
+                    "upload_downloaded": ["transform"],
+                    "transform": ["upload_transformed"],
+                    "upload_transformed": ["bq_load"],
+                    "bq_load": ["cleanup"],
+                    "cleanup": ["add_new_dataset_releases"],
+                    "add_new_dataset_releases": [],
+                },
+                dag,
+            )
+
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_load(self, m_makeapi):
         """Test that the DAG can be loaded from a DAG bag."""
 
+        m_makeapi.return_value = self.api
         dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "scopus_telescope.py")
-
         env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
 
         with env.create():
             self.setup_connections(env)
-            self.setup_api(env)
+            self.setup_api()
 
             dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "scopus_telescope.py")
             dag_id = make_dag_id(ScopusTelescope.DAG_ID, self.org_name)
             self.assert_dag_load(dag_id, dag_file)
 
-    def test_dag_load_missing_params(self):
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_load_missing_params(self, m_makeapi):
         """Test that the DAG can be loaded from a DAG bag."""
 
+        m_makeapi.return_value = self.api
         dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "scopus_telescope.py")
         env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
         extra = {
@@ -780,18 +832,22 @@ class TestScopusTelescope(ObservatoryTestCase):
 
         with env.create():
             self.setup_connections(env)
-            self.setup_api(env, extra=extra)
+            self.setup_api(extra=extra)
 
             dag_file = os.path.join(module_file_path("academic_observatory_workflows.dags"), "scopus_telescope.py")
             dag_id = make_dag_id(ScopusTelescope.DAG_ID, self.org_name)
             self.assertRaises(AssertionError, self.assert_dag_load, dag_id, dag_file)
 
-    def test_telescope(self):
+    @patch("academic_observatory_workflows.workflows.web_of_science_telescope.pendulum.now")
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_telescope(self, m_makeapi, m_pendnow):
+        m_makeapi.return_value = self.api
+        m_pendnow.return_value = pendulum.datetime(2021, 2, 1)
         env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.api_port)
 
         with env.create():
             self.setup_connections(env)
-            self.setup_api(env)
+            self.setup_api()
             dataset_id = env.add_dataset()
 
             execution_date = pendulum.datetime(2021, 1, 1)
@@ -879,3 +935,11 @@ class TestScopusTelescope(ObservatoryTestCase):
                 env.run_task(telescope.cleanup.__name__)
                 self.assertEqual(ti.state, State.SUCCESS)
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                # add_dataset_release_task
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 0)
+                ti = env.run_task("add_new_dataset_releases")
+                self.assertEqual(ti.state, State.SUCCESS)
+                dataset_releases = get_dataset_releases(dataset_id=1)
+                self.assertEqual(len(dataset_releases), 1)

--- a/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
@@ -59,14 +59,12 @@ from observatory.platform.utils.workflow_utils import (
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
 from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
@@ -675,13 +673,13 @@ class TestScopusTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
             type_id="partitioned",
@@ -709,7 +707,7 @@ class TestScopusTelescope(ObservatoryTestCase):
             name="Scopus Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Telescope(id=1),
+            connection=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
@@ -707,7 +707,7 @@ class TestScopusTelescope(ObservatoryTestCase):
             name="Scopus Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
@@ -669,9 +669,9 @@ class TestScopusTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_scopus_telescope.py
@@ -64,7 +64,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -664,8 +664,8 @@ class TestScopusTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Scopus Telescope"
-        telescope_type = TelescopeType(name=name, type_id=ScopusTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=ScopusTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -677,7 +677,7 @@ class TestScopusTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
@@ -716,8 +716,8 @@ class TestScopusTelescope(ObservatoryTestCase):
 
     def get_telescope(self, dataset_id):
         api = make_observatory_api()
-        telescope_type = api.get_telescope_type(type_id=ScopusTelescope.DAG_ID)
-        telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+        workflow_type = api.get_workflow_type(type_id=ScopusTelescope.DAG_ID)
+        telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
         self.assertEqual(len(telescopes), 1)
         dataset_type = api.get_dataset_type(type_id="scopus")
 

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
@@ -43,7 +43,7 @@ from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.workflow import Workflow
 from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
@@ -52,7 +52,6 @@ from observatory.api.client.model.table_type import TableType
 from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.airflow_utils import AirflowConns
 from airflow.models import Connection
-
 
 
 class TestUnpaywallSnapshotRelease(ObservatoryTestCase):
@@ -233,29 +232,35 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         )
         self.api.put_organisation(organisation)
 
-        telescope = Telescope(
+        telescope = Workflow(
             name=name,
             workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
-        self.api.put_telescope(telescope)
+        self.api.put_workflow(telescope)
 
         table_type = TableType(
-                type_id="partitioned",
-                name="partitioned bq table",
+            type_id="partitioned",
+            name="partitioned bq table",
         )
         self.api.put_table_type(table_type)
 
         dataset_type = DatasetType(
-                type_id="dataset_type_id",
-                name="ds type",
-                extra={},
-                table_type=TableType(id=1),
+            type_id="dataset_type_id",
+            name="ds type",
+            extra={},
+            table_type=TableType(id=1),
         )
         self.api.put_dataset_type(dataset_type)
 
-        dataset = Dataset(name="Unpaywall Snapshot Dataset", address="project.dataset.table", service="bigquery", connection=Telescope(id=1), dataset_type=DatasetType(id=1))
+        dataset = Dataset(
+            name="Unpaywall Snapshot Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=Workflow(id=1),
+            dataset_type=DatasetType(id=1),
+        )
         self.api.put_dataset(dataset)
 
     def setup_connections(self, env):

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
@@ -258,7 +258,7 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
             name="Unpaywall Snapshot Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
@@ -44,7 +44,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -222,8 +222,8 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         dt = pendulum.now("UTC")
 
         name = "Unpaywall Snapshot Telescope"
-        telescope_type = TelescopeType(name=name, type_id=UnpaywallSnapshotTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=UnpaywallSnapshotTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -235,7 +235,7 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
@@ -20,7 +20,6 @@ import os
 import shutil
 from typing import List
 from unittest.mock import patch
-
 import pendulum
 import vcr
 from academic_observatory_workflows.config import test_fixtures_folder
@@ -40,6 +39,20 @@ from observatory.platform.utils.workflow_utils import (
     bigquery_sharded_table_id,
     blob_name,
 )
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.telescope import Telescope
+from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.table_type import TableType
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.airflow_utils import AirflowConns
+from airflow.models import Connection
+
 
 
 class TestUnpaywallSnapshotRelease(ObservatoryTestCase):
@@ -58,7 +71,7 @@ class TestUnpaywallSnapshotRelease(ObservatoryTestCase):
         self.unpaywall_test_path = test_fixtures_folder("unpaywall_snapshot", "unpaywall_snapshot.jsonl.gz")
         self.unpaywall_test_file = "unpaywall_3000-01-27T153236.jsonl.gz"
         self.unpaywall_test_url = "http://localhost/unpaywall_3000-01-27T153236.jsonl.gz"
-        self.unpaywall_test_date = pendulum.datetime(year=3000, month=1, day=27)
+        self.unpaywall_test_date = pendulum.datetime(3000, 1, 27, 15, 32, 36)
         self.unpaywall_test_decompress_hash = "fe4e72ce54c4bb236802ddbb3dbee905"
         self.unpaywall_test_transform_hash = "62cbb5af5a78d2e0769a28d976971cba"
 
@@ -196,14 +209,74 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
         self.unpaywall_test_path = test_fixtures_folder("unpaywall_snapshot", "unpaywall_snapshot.jsonl.gz")
 
-    def test_ctor(self):
-        # set table description
-        telescope = UnpaywallSnapshotTelescope(table_descriptions="something")
-        self.assertEqual(telescope.table_descriptions, "something")
+        # API environment
+        self.host = "localhost"
+        self.port = 5001
+        configuration = Configuration(host=f"http://{self.host}:{self.port}")
+        api_client = ApiClient(configuration)
+        self.api = ObservatoryApi(api_client=api_client)  # noqa: E501
+        self.env = ObservatoryApiEnvironment(host=self.host, port=self.port)
+        self.org_name = "Curtin University"
 
-        # set airflow_vars
-        telescope = UnpaywallSnapshotTelescope(airflow_vars=[])
-        self.assertEqual(telescope.airflow_vars, ["transform_bucket"])
+    def setup_api(self):
+        dt = pendulum.now("UTC")
+
+        name = "Unpaywall Snapshot Telescope"
+        telescope_type = TelescopeType(name=name, type_id=UnpaywallSnapshotTelescope.DAG_ID)
+        self.api.put_telescope_type(telescope_type)
+
+        organisation = Organisation(
+            name="Curtin University",
+            gcp_project_id="project",
+            gcp_download_bucket="download_bucket",
+            gcp_transform_bucket="transform_bucket",
+        )
+        self.api.put_organisation(organisation)
+
+        telescope = Telescope(
+            name=name,
+            telescope_type=TelescopeType(id=1),
+            organisation=Organisation(id=1),
+            extra={},
+        )
+        self.api.put_telescope(telescope)
+
+        table_type = TableType(
+                type_id="partitioned",
+                name="partitioned bq table",
+        )
+        self.api.put_table_type(table_type)
+
+        dataset_type = DatasetType(
+                type_id="dataset_type_id",
+                name="ds type",
+                extra={},
+                table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type)
+
+        dataset = Dataset(name="Unpaywall Snapshot Dataset", address="project.dataset.table", service="bigquery", connection=Telescope(id=1), dataset_type=DatasetType(id=1))
+        self.api.put_dataset(dataset)
+
+    def setup_connections(self, env):
+        # Add Observatory API connection
+        conn = Connection(conn_id=AirflowConns.OBSERVATORY_API, uri=f"http://:password@{self.host}:{self.port}")
+        env.add_connection(conn)
+
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_ctor(self, m_makeapi):
+        m_makeapi.return_value = self.api
+
+        with self.env.create():
+            self.setup_api()
+
+            # set table description
+            telescope = UnpaywallSnapshotTelescope(table_descriptions="something", workflow_id=1)
+            self.assertEqual(telescope.table_descriptions, "something")
+
+            # set airflow_vars
+            telescope = UnpaywallSnapshotTelescope(airflow_vars=[])
+            self.assertEqual(telescope.airflow_vars, ["transform_bucket"])
 
     @patch("academic_observatory_workflows.workflows.unpaywall_snapshot_telescope.get_airflow_connection_url")
     @patch("observatory.platform.utils.workflow_utils.Variable.get")
@@ -216,8 +289,6 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         data_path = "data"
         mock_variable_get.return_value = data_path
         m_get_conn.return_value = "http://localhost/"
-
-        telescope = UnpaywallSnapshotTelescope()
 
         with CliRunner().isolated_filesystem():
             with vcr.use_cassette(self.list_unpaywall_releases_path):
@@ -235,7 +306,6 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         m_get.return_value = data_path
         m_get_conn.return_value = "http://localhost/"
         m_get_xml_dict.side_effect = ConnectionError("Test")
-        telescope = UnpaywallSnapshotTelescope()
 
         # Fetch error
         self.assertRaises(ConnectionError, UnpaywallSnapshotTelescope.list_releases, self.start_date, self.end_date)
@@ -247,8 +317,6 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         data_path = "data"
         m_get.return_value = data_path
         m_get_conn.return_value = "http://localhost/"
-
-        telescope = UnpaywallSnapshotTelescope()
 
         m_get_xmldict.return_value = {
             "ListBucketResult": {
@@ -265,90 +333,113 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
         def xcom_push(self, *args):
             pass
 
-    @patch("academic_observatory_workflows.workflows.unpaywall_snapshot_telescope.bigquery_table_exists")
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
     @patch(
         "academic_observatory_workflows.workflows.unpaywall_snapshot_telescope.UnpaywallSnapshotTelescope.list_releases"
     )
     @patch("observatory.platform.utils.workflow_utils.Variable.get")
-    def test_get_release_info(self, m_get, m_releases, m_bq_table_exist):
+    def test_get_release_info(self, m_get, m_releases, m_makeapi):
         m_get.return_value = "projectid"
+        m_makeapi.return_value = self.api
 
         # No release
         m_releases.return_value = []
-        m_bq_table_exist.return_value = True
-        telescope = UnpaywallSnapshotTelescope()
-        continue_dag = telescope.get_release_info(
-            **{
-                "ti": TestUnpaywallSnapshotTelescope.MockTI(),
-                "execution_date": datetime.datetime(2021, 1, 1),
-                "next_execution_date": datetime.datetime(2021, 2, 1),
-            }
-        )
 
-        self.assertEqual(continue_dag, False)
+        with self.env.create():
+            self.setup_api()
+            telescope = UnpaywallSnapshotTelescope(workflow_id=1)
+            continue_dag = telescope.get_release_info(
+                **{
+                    "ti": TestUnpaywallSnapshotTelescope.MockTI(),
+                    "execution_date": datetime.datetime(2021, 1, 1),
+                    "next_execution_date": datetime.datetime(2021, 2, 1),
+                }
+            )
 
-        # Single release exists
-        m_releases.return_value = [{"date": "20210101", "file_name": "some file"}]
-        m_bq_table_exist.return_value = True
-        continue_dag = telescope.get_release_info(
-            **{
-                "ti": TestUnpaywallSnapshotTelescope.MockTI(),
-                "execution_date": datetime.datetime(2021, 1, 1),
-                "next_execution_date": datetime.datetime(2021, 2, 1),
-            }
-        )
-        self.assertEqual(continue_dag, False)
+            self.assertEqual(continue_dag, False)
 
-        # Single release, not exist
-        m_releases.return_value = [{"date": "20210101", "file_name": "some file"}]
-        m_bq_table_exist.return_value = False
-        continue_dag = telescope.get_release_info(
-            **{
-                "ti": TestUnpaywallSnapshotTelescope.MockTI(),
-                "execution_date": datetime.datetime(2021, 1, 1),
-                "next_execution_date": datetime.datetime(2021, 2, 1),
-            }
-        )
-        self.assertEqual(continue_dag, True)
+            # Single release, not processed
+            m_releases.return_value = [{"date": "20210101", "file_name": "some file"}]
+            continue_dag = telescope.get_release_info(
+                **{
+                    "ti": TestUnpaywallSnapshotTelescope.MockTI(),
+                    "execution_date": datetime.datetime(2021, 1, 1),
+                    "next_execution_date": datetime.datetime(2021, 2, 1),
+                }
+            )
+            self.assertEqual(continue_dag, True)
 
-    def test_dag_structure(self):
+            # Single release, already processed
+            m_releases.return_value = [{"date": "20210101", "file_name": "some file"}]
+            dt = pendulum.datetime(2021, 1, 1)
+            dataset_release = DatasetRelease(
+                dataset=Dataset(id=1),
+                start_date=dt,
+                end_date=dt,
+            )
+            self.api.put_dataset_release(dataset_release)
+
+            continue_dag = telescope.get_release_info(
+                **{
+                    "ti": TestUnpaywallSnapshotTelescope.MockTI(),
+                    "execution_date": datetime.datetime(2021, 1, 1),
+                    "next_execution_date": datetime.datetime(2021, 2, 1),
+                }
+            )
+            self.assertEqual(continue_dag, False)
+
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_structure(self, m_makeapi):
         """Test that the Crossref Events DAG has the correct structure."""
 
-        dag = UnpaywallSnapshotTelescope().make_dag()
-        self.assert_dag_structure(
-            {
-                "check_dependencies": ["get_release_info"],
-                "get_release_info": ["download"],
-                "download": ["upload_downloaded"],
-                "upload_downloaded": ["extract"],
-                "extract": ["transform"],
-                "transform": ["upload_transformed"],
-                "upload_transformed": ["bq_load"],
-                "bq_load": ["cleanup"],
-                "cleanup": [],
-            },
-            dag,
-        )
+        m_makeapi.return_value = self.api
 
-    def test_dag_load(self):
+        with self.env.create():
+            self.setup_api()
+            dag = UnpaywallSnapshotTelescope().make_dag()
+            self.assert_dag_structure(
+                {
+                    "check_dependencies": ["get_release_info"],
+                    "get_release_info": ["download"],
+                    "download": ["upload_downloaded"],
+                    "upload_downloaded": ["extract"],
+                    "extract": ["transform"],
+                    "transform": ["upload_transformed"],
+                    "upload_transformed": ["bq_load"],
+                    "bq_load": ["cleanup"],
+                    "cleanup": ["add_new_dataset_releases"],
+                    "add_new_dataset_releases": [],
+                },
+                dag,
+            )
+
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
+    def test_dag_load(self, m_makeapi):
         """Test that the DAG can be loaded from a DAG bag."""
 
-        with ObservatoryEnvironment().create():
+        m_makeapi.return_value = self.api
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
+
+        with env.create():
+            self.setup_connections(env)
+            self.setup_api()
             dag_file = os.path.join(
                 module_file_path("academic_observatory_workflows.dags"), "unpaywall_snapshot_telescope.py"
             )
             self.assert_dag_load("unpaywall_snapshot", dag_file)
 
     def setup_observatory_env(self):
-        env = ObservatoryEnvironment(self.project_id, self.data_location)
+        env = ObservatoryEnvironment(self.project_id, self.data_location, api_host=self.host, api_port=self.port)
         self.dataset_id = env.add_dataset()
         return env
 
+    @patch("observatory.platform.utils.release_utils.make_observatory_api")
     @patch("airflow.hooks.base.BaseHook.get_connection")
-    def test_telescope(self, m_base_get_con):
+    def test_telescope(self, m_base_get_con, m_makeapi):
         """Test the Telescope end to end."""
 
         m_base_get_con.return_value = "http://localhost"
+        m_makeapi.return_value = self.api
 
         # Setup http server to serve files
         httpserver = HttpServer(directory=test_fixtures_folder("unpaywall_snapshot"))
@@ -368,7 +459,8 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
                 file_name = "unpaywall_snapshot.jsonl.gz"
 
                 with env.create():
-                    telescope = UnpaywallSnapshotTelescope(dataset_id=self.dataset_id)
+                    self.setup_api()
+                    telescope = UnpaywallSnapshotTelescope(dataset_id=self.dataset_id, workflow_id=1)
                     dag = telescope.make_dag()
 
                     release = UnpaywallSnapshotRelease(
@@ -443,3 +535,11 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
                         env.run_task(telescope.cleanup.__name__)
                         self.assertEqual(ti.state, State.SUCCESS)
                         self.assert_cleanup(download_folder, extract_folder, transform_folder)
+
+                        # add_dataset_release_task
+                        dataset_releases = get_dataset_releases(dataset_id=1)
+                        self.assertEqual(len(dataset_releases), 0)
+                        ti = env.run_task("add_new_dataset_releases")
+                        self.assertEqual(ti.state, State.SUCCESS)
+                        dataset_releases = get_dataset_releases(dataset_id=1)
+                        self.assertEqual(len(dataset_releases), 1)

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_snapshot_telescope.py
@@ -227,9 +227,9 @@ class TestUnpaywallSnapshotTelescope(ObservatoryTestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -82,9 +82,9 @@ class TestUnpaywallRelease(unittest.TestCase):
 
         organisation = Organisation(
             name="Curtin University",
-            gcp_project_id="project",
-            gcp_download_bucket="download_bucket",
-            gcp_transform_bucket="transform_bucket",
+            project_id="project",
+            download_bucket="download_bucket",
+            transform_bucket="transform_bucket",
         )
         self.api.put_organisation(organisation)
 

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -112,7 +112,7 @@ class TestUnpaywallRelease(unittest.TestCase):
             name="Unpaywall Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         self.api.put_dataset(dataset)
@@ -365,7 +365,7 @@ class TestUnpaywallTelescope(ObservatoryTestCase):
             name="Unpaywall Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=Workflow(id=1),
+            workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
         result = self.api.put_dataset(dataset)

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -317,7 +317,7 @@ class TestUnpaywallTelescope(ObservatoryTestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.project_id = os.getenv("TESTS_GOOGLE_CLOUD_PROJECT_ID")
+        self.project_id = os.getenv("TEST_GCP_PROJECT_ID")
         self.data_location = os.getenv("TEST_GCP_DATA_LOCATION")
 
         self.fixture_dir = test_fixtures_folder("unpaywall")

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -47,7 +47,7 @@ from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.telescope import Telescope
-from observatory.api.client.model.telescope_type import TelescopeType
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_release import DatasetRelease
 from observatory.api.client.model.dataset_type import DatasetType
@@ -77,8 +77,8 @@ class TestUnpaywallRelease(unittest.TestCase):
         dt = pendulum.now("UTC")
 
         name = "Unpaywall Telescope"
-        telescope_type = TelescopeType(name=name, type_id=UnpaywallTelescope.DAG_ID)
-        self.api.put_telescope_type(telescope_type)
+        workflow_type = WorkflowType(name=name, type_id=UnpaywallTelescope.DAG_ID)
+        self.api.put_workflow_type(workflow_type)
 
         organisation = Organisation(
             name="Curtin University",
@@ -90,7 +90,7 @@ class TestUnpaywallRelease(unittest.TestCase):
 
         telescope = Telescope(
             name=name,
-            telescope_type=TelescopeType(id=1),
+            workflow_type=WorkflowType(id=1),
             organisation=Organisation(id=1),
             extra={},
         )
@@ -335,11 +335,11 @@ class TestUnpaywallTelescope(ObservatoryTestCase):
         result = self.api.put_organisation(org)
         self.assertIsInstance(result, Organisation)
 
-        tele_type = TelescopeType(type_id=UnpaywallTelescope.DAG_ID, name="Unpaywall")
-        result = self.api.put_telescope_type(tele_type)
-        self.assertIsInstance(result, TelescopeType)
+        tele_type = WorkflowType(type_id=UnpaywallTelescope.DAG_ID, name="Unpaywall")
+        result = self.api.put_workflow_type(tele_type)
+        self.assertIsInstance(result, WorkflowType)
 
-        telescope = Telescope(organisation=Organisation(id=1), telescope_type=TelescopeType(id=1))
+        telescope = Telescope(organisation=Organisation(id=1), workflow_type=WorkflowType(id=1))
         result = self.api.put_telescope(telescope)
         self.assertIsInstance(result, Telescope)
 

--- a/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
@@ -817,9 +817,9 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
             name=self.org_name,
             created=dt,
             modified=dt,
-            gcp_project_id=self.project_id,
-            gcp_download_bucket=env.download_bucket,
-            gcp_transform_bucket=env.transform_bucket,
+            project_id=self.project_id,
+            download_bucket=env.download_bucket,
+            transform_bucket=env.transform_bucket,
         )
 
         env.api_session.add(organisation)

--- a/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
@@ -42,7 +42,6 @@ from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.api import make_observatory_api
 from observatory.platform.utils.gc_utils import run_bigquery_query
 from observatory.platform.utils.test_utils import (
-    HttpServer,
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
@@ -823,7 +822,7 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
         )
 
         env.api_session.add(organisation)
-        telescope = orm.Telescope(
+        telescope = orm.Workflow(
             name=name,
             workflow_type=workflow_type,
             organisation=organisation,
@@ -856,7 +855,15 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
         )
         env.api_session.commit()
 
-        dataset = orm.Dataset(name="Web of Science Dataset", address="project.dataset.table", service="bigquery", connection=telescope, dataset_type={"id": 1}, created=dt, modified=dt)
+        dataset = orm.Dataset(
+            name="Web of Science Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            connection=telescope,
+            dataset_type={"id": 1},
+            created=dt,
+            modified=dt,
+        )
         env.api_session.add(dataset)
         env.api_session.commit()
 
@@ -872,7 +879,7 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
     def get_telescope(self, dataset_id):
         api = make_observatory_api()
         workflow_type = api.get_workflow_type(type_id=WebOfScienceTelescope.DAG_ID)
-        telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
+        telescopes = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
         self.assertEqual(len(telescopes), 1)
 
         dag_id = make_dag_id(WebOfScienceTelescope.DAG_ID, telescopes[0].organisation.name)
@@ -932,7 +939,11 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
             self.setup_connections(env)
             self.setup_api(env)
             telescope = WebOfScienceTelescope(
-                dag_id="web_of_science", airflow_conns=["conn"], airflow_vars=[], institution_ids=["123"], workflow_id=1,
+                dag_id="web_of_science",
+                airflow_conns=["conn"],
+                airflow_vars=[],
+                institution_ids=["123"],
+                workflow_id=1,
             )
             dag = telescope.make_dag()
             self.assert_dag_structure(

--- a/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
@@ -810,8 +810,8 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
             }
 
         name = "Web of Science Telescope"
-        telescope_type = orm.TelescopeType(name=name, type_id=WebOfScienceTelescope.DAG_ID, created=dt, modified=dt)
-        env.api_session.add(telescope_type)
+        workflow_type = orm.WorkflowType(name=name, type_id=WebOfScienceTelescope.DAG_ID, created=dt, modified=dt)
+        env.api_session.add(workflow_type)
 
         organisation = orm.Organisation(
             name=self.org_name,
@@ -825,7 +825,7 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
         env.api_session.add(organisation)
         telescope = orm.Telescope(
             name=name,
-            telescope_type=telescope_type,
+            workflow_type=workflow_type,
             organisation=organisation,
             modified=dt,
             created=dt,
@@ -871,8 +871,8 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
 
     def get_telescope(self, dataset_id):
         api = make_observatory_api()
-        telescope_type = api.get_telescope_type(type_id=WebOfScienceTelescope.DAG_ID)
-        telescopes = api.get_telescopes(telescope_type_id=telescope_type.id, limit=1000)
+        workflow_type = api.get_workflow_type(type_id=WebOfScienceTelescope.DAG_ID)
+        telescopes = api.get_telescopes(workflow_type_id=workflow_type.id, limit=1000)
         self.assertEqual(len(telescopes), 1)
 
         dag_id = make_dag_id(WebOfScienceTelescope.DAG_ID, telescopes[0].organisation.name)

--- a/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
@@ -859,7 +859,7 @@ class TestWebOfScienceTelescope(ObservatoryTestCase):
             name="Web of Science Dataset",
             address="project.dataset.table",
             service="bigquery",
-            connection=telescope,
+            workflow=telescope,
             dataset_type={"id": 1},
             created=dt,
             modified=dt,

--- a/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
@@ -47,7 +47,10 @@ class UnpaywallSnapshotRelease(SnapshotRelease):
     AIRFLOW_CONNECTION = "unpaywall_snapshot"
 
     def __init__(
-        self, dag_id: str, release_date: pendulum.DateTime, file_name: str = None,
+        self,
+        dag_id: str,
+        release_date: pendulum.DateTime,
+        file_name: str = None,
     ):
         """Construct an UnpaywallSnapshotRelease instance.
 
@@ -57,7 +60,8 @@ class UnpaywallSnapshotRelease(SnapshotRelease):
         """
 
         super().__init__(
-            dag_id=dag_id, release_date=release_date,
+            dag_id=dag_id,
+            release_date=release_date,
         )
 
         self.file_name = file_name
@@ -205,7 +209,6 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         self.add_task(self.bq_load)
         self.add_task(self.cleanup)
         self.add_task(self.add_new_dataset_releases)
-        
 
     @staticmethod
     def list_releases(start_date: pendulum.DateTime, end_date: pendulum.DateTime) -> List[Dict]:
@@ -260,7 +263,7 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         releases_list = UnpaywallSnapshotTelescope.list_releases(execution_date, next_execution_date)
         logging.info(f"Releases between {execution_date} and {next_execution_date}:\n{releases_list}\n")
 
-        dataset = get_datasets(telescope_id=self.workflow_id)[0]
+        dataset = get_datasets(workflow_id=self.workflow_id)[0]
         releases = [pendulum.parse(release["date"]) for release in releases_list]
         new_dates = get_new_release_dates(dataset_id=dataset.id, releases=releases)
         new_releases = list(filter(lambda release: release["date"] in new_dates, releases_list))

--- a/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
@@ -27,10 +27,6 @@ from observatory.platform.utils.airflow_utils import (
     get_airflow_connection_url,
 )
 from observatory.platform.utils.file_utils import find_replace_file, gunzip_files
-from observatory.platform.utils.gc_utils import (
-    bigquery_sharded_table_id,
-    bigquery_table_exists,
-)
 from observatory.platform.utils.http_download import download_file
 from observatory.platform.utils.url_utils import (
     get_http_response_xml_to_dict,
@@ -40,6 +36,7 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
+from observatory.platform.utils.release_utils import get_new_release_dates, get_datasets
 
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
@@ -50,10 +47,7 @@ class UnpaywallSnapshotRelease(SnapshotRelease):
     AIRFLOW_CONNECTION = "unpaywall_snapshot"
 
     def __init__(
-        self,
-        dag_id: str,
-        release_date: pendulum.DateTime,
-        file_name: str = None,
+        self, dag_id: str, release_date: pendulum.DateTime, file_name: str = None,
     ):
         """Construct an UnpaywallSnapshotRelease instance.
 
@@ -63,8 +57,7 @@ class UnpaywallSnapshotRelease(SnapshotRelease):
         """
 
         super().__init__(
-            dag_id=dag_id,
-            release_date=release_date,
+            dag_id=dag_id, release_date=release_date,
         )
 
         self.file_name = file_name
@@ -111,7 +104,7 @@ class UnpaywallSnapshotRelease(SnapshotRelease):
         :return: date.
         """
 
-        date = re.search(r"\d{4}-\d{2}-\d{2}", file_name).group()
+        date = re.search(r"\d{4}-\d{2}-\d{2}T\d{1,}", file_name).group()
         return pendulum.parse(date)
 
     def download(self):
@@ -151,6 +144,8 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         table_descriptions: Dict = None,
         catchup: bool = True,
         airflow_vars: Union[List[AirflowVars], None] = None,
+        org_name: str = "Curtin University",
+        workflow_id: int = None,
     ):
         """Initialise the telescope.
 
@@ -164,6 +159,8 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         :param table_descriptions: Descriptions of the tables.
         :param catchup: Whether Airflow should catch up past dag runs.
         :param airflow_vars: List of Airflow variables to use.
+        :param org_name: Organisation name in the API associated with this Telescope instance.
+        :param workflow_id: api workflow id.
         """
 
         if table_descriptions is None:
@@ -195,6 +192,7 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
             airflow_vars=airflow_vars,
             airflow_conns=airflow_conns,
             queue=queue,
+            workflow_id=workflow_id,
         )
 
         self.add_setup_task(self.check_dependencies)
@@ -206,6 +204,8 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         self.add_task(self.upload_transformed)
         self.add_task(self.bq_load)
         self.add_task(self.cleanup)
+        self.add_task(self.add_new_dataset_releases)
+        
 
     @staticmethod
     def list_releases(start_date: pendulum.DateTime, end_date: pendulum.DateTime) -> List[Dict]:
@@ -254,33 +254,23 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         :return: Whether the DAG should continue.
         """
 
-        # Get variables
-        project_id = Variable.get(AirflowVars.PROJECT_ID)
-
         # List releases between a start and end date
         execution_date = pendulum.instance(kwargs["execution_date"])
         next_execution_date = pendulum.instance(kwargs["next_execution_date"])
         releases_list = UnpaywallSnapshotTelescope.list_releases(execution_date, next_execution_date)
         logging.info(f"Releases between {execution_date} and {next_execution_date}:\n{releases_list}\n")
 
-        # Check if the BigQuery table exists for each release to see if the workflow needs to process
-        releases_list_out = []
-        for release in releases_list:
-            table_id = bigquery_sharded_table_id(UnpaywallSnapshotTelescope.DAG_ID, pendulum.parse(release["date"]))
-
-            file = release["file_name"]
-            if bigquery_table_exists(project_id, self.dataset_id, table_id):
-                logging.info(f"Skipping as table exists for {file}: " f"{project_id}.{self.dataset_id}.{table_id}")
-            else:
-                logging.info(f"Table doesn't exist yet, processing {file} in this workflow")
-                releases_list_out.append(release)
+        dataset = get_datasets(telescope_id=self.workflow_id)[0]
+        releases = [pendulum.parse(release["date"]) for release in releases_list]
+        new_dates = get_new_release_dates(dataset_id=dataset.id, releases=releases)
+        new_releases = list(filter(lambda release: release["date"] in new_dates, releases_list))
 
         # If releases_list_out contains items then the DAG will continue (return True) otherwise it will
         # stop (return False)
-        continue_dag = len(releases_list_out) > 0
+        continue_dag = len(new_releases) > 0
         if continue_dag:
             ti: TaskInstance = kwargs["ti"]
-            ti.xcom_push(UnpaywallSnapshotTelescope.RELEASE_INFO, releases_list_out, execution_date)
+            ti.xcom_push(UnpaywallSnapshotTelescope.RELEASE_INFO, new_releases, execution_date)
         return continue_dag
 
     def make_release(self, **kwargs) -> List[UnpaywallSnapshotRelease]:

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -113,7 +113,7 @@ class UnpaywallRelease(StreamRelease):
         :return: Whether this is the second run.
         """
 
-        datasets = get_datasets(telescope_id=workflow_id)
+        datasets = get_datasets(workflow_id=workflow_id)
         releases = get_dataset_releases(dataset_id=datasets[0].id)
         return len(releases) == 1
 
@@ -149,7 +149,7 @@ class UnpaywallRelease(StreamRelease):
         :return: List of releases available.
         """
 
-        dataset = get_datasets(telescope_id=workflow_id)[0]
+        dataset = get_datasets(workflow_id=workflow_id)[0]
         api_releases = get_dataset_releases(dataset_id=dataset.id)
         latest_release = get_latest_dataset_release(api_releases)
 
@@ -287,7 +287,7 @@ class UnpaywallTelescope(StreamTelescope):
             start_date = UnpaywallTelescope._get_snapshot_date().isoformat()
             end_date = start_date
         else:
-            dataset = get_datasets(telescope_id=self.workflow_id)[0]
+            dataset = get_datasets(workflow_id=self.workflow_id)[0]
             api_releases = get_dataset_releases(dataset_id=dataset.id)
             latest_release = get_latest_dataset_release(api_releases)
             start_date = latest_release.start_date.isoformat()


### PR DESCRIPTION
Depends on [INF-325/dataset_release_utils](https://github.com/The-Academic-Observatory/observatory-platform/tree/INF-325/dataset_release_utils)

- Adds basic dataset release record creation in the api for new successful data ingestion runs in snapshot, stream telescopes, and the doi workflow.