### PR TITLE
OpenAlex fixes

### DIFF
--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -105,8 +105,8 @@ class OpenAlexRelease(StreamRelease):
         logging.info(
             f"Writing info on updated entities from 'author' and 'venue' to" f" {self.transfer_manifest_path_transform}"
         )
-
-        s3client = boto3.client("s3")
+        aws_access_key_id, aws_secret_access_key = get_aws_conn_info()
+        s3client = boto3.client("s3", aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key)
 
         updated_entities_count = 0
         with open(self.transfer_manifest_path_download, "w") as f_download, open(
@@ -191,7 +191,9 @@ class OpenAlexRelease(StreamRelease):
             "activate-service-account",
             f"--key-file" f"={os.environ['GOOGLE_APPLICATION_CREDENTIALS']}",
         ]
-        proc: Popen = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        proc: Popen = subprocess.Popen(
+            args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=dict(os.environ, CLOUDSDK_PYTHON="python3")
+        )
         run_subprocess_cmd(proc, args)
 
         logging.info(f"Downloading transferred files from Google Cloud bucket: {self.download_bucket}")

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -465,8 +465,9 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
     @patch("academic_observatory_workflows.workflows.openalex_telescope.boto3.client")
+    @patch("academic_observatory_workflows.workflows.openalex_telescope.get_aws_conn_info")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.Variable.get")
-    def test_write_transfer_manifest(self, mock_variable_get, mock_boto3):
+    def test_write_transfer_manifest(self, mock_variable_get, mock_aws_info, mock_boto3):
         """Test write_transfer_manifest method of the OpenAlex release.
 
         :param mock_variable_get: Mock Airflow Variable get() method
@@ -474,6 +475,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         :return: None.
         """
         mock_variable_get.return_value = "data"
+        mock_aws_info.return_value = "key_id", "secret_key"
         # Mock response of get_object on last_modified file, mocking lambda file
         side_effect = []
         for tests in range(2):


### PR DESCRIPTION
- Add aws credentials to get transfer manifest file.
- Fix gcloud error by adding cloudsdk_python environment variable.