### PR TITLE
Save JSON index for the filtering API and COKI Open Access Dataset release

### DIFF
--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -305,6 +305,13 @@ def save_json(path: str, data: Union[Dict, List]):
         json.dump(data, f, separators=(",", ":"))
 
 
+def val_empty(val):
+    if isinstance(val, list):
+        return len(val) == 0
+    else:
+        return val is None or val == ""
+
+
 def clean_ror_id(ror_id: str):
     """Remove the https://ror.org/ prefix from a ROR id.
 
@@ -371,13 +378,6 @@ def select_subset(original: Dict, include_keys: Dict):
                 output[k] = original[k]
 
     return output
-
-
-def val_empty(val):
-    if isinstance(val, list):
-        return len(val) == 0
-    else:
-        return val is None or val == ""
 
 
 @dataclasses.dataclass

--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -105,7 +105,7 @@ is licenced under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 This work contains information from:
 * [Microsoft Academic Graph](https://www.microsoft.com/en-us/research/project/microsoft-academic-graph/) which is made available under the [ODC Attribution License](https://opendatacommons.org/licenses/by/1-0/).
 * [Crossref Metadata](https://www.crossref.org/documentation/metadata-plus/) via the Metadata Plus program. Bibliographic metadata is made available without copyright restriction and Crossref generated data with a [CC0 licence](https://creativecommons.org/share-your-work/public-domain/cc0/). See [metadata licence information](https://www.crossref.org/documentation/retrieve-metadata/rest-api/rest-api-metadata-license-information/) for more details.
-* [Unpaywall](https://unpaywall.org/products/data-feed) which is made available under a [CC0 licence](https://creativecommons.org/share-your-work/public-domain/cc0/).
+* [Unpaywall Data Feed](https://unpaywall.org/products/data-feed).
 * [Research Organization Registry](https://ror.org/) which is made available under a [CC0 licence](https://creativecommons.org/share-your-work/public-domain/cc0/).
 """
 

--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -284,12 +284,16 @@ class Stats:
     start_year: int
     end_year: int
     last_updated: str
+    n_countries: int
+    n_institutions: int
 
     def to_dict(self) -> Dict:
         return {
             "start_year": self.start_year,
             "end_year": self.end_year,
             "last_updated": self.last_updated,
+            "n_countries": self.n_countries,
+            "n_institutions": self.n_institutions,
         }
 
 
@@ -1510,7 +1514,9 @@ class OaWebWorkflow(Workflow):
         # Save stats as json
         end_year = pendulum.now().year - 1
         last_updated = pendulum.now().format("D MMMM YYYY")
-        stats = Stats(START_YEAR, end_year, last_updated)
+        n_countries = len(countries)
+        n_institutions = len(institutions)
+        stats = Stats(START_YEAR, end_year, last_updated, n_countries, n_institutions)
         release.save_stats(stats)
         logging.info(f"Saved stats data")
 

--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -625,6 +625,19 @@ def clean_url(url: str) -> str:
     return f"{p.scheme}://{p.netloc}/"
 
 
+def save_as_jsonl(output_path: str, iterable: List[Dict]):
+    """Save a list of dicts to JSON Lines format.
+
+    :param output_path: the file path.
+    :param iterable: the objects to save.
+    :return: None.
+    """
+
+    with open(output_path, "w") as f:
+        with jsonlines.Writer(f) as writer:
+            writer.write_all(iterable)
+
+
 def make_logo_url(*, category: str, entity_id: str, size: str, fmt: str) -> str:
     """Make a logo url.
 
@@ -666,19 +679,6 @@ def calc_oa_stats(
     n_outputs_publisher_open_only = n_outputs_publisher_open - n_outputs_both
 
     return n_outputs_publisher_open_only, n_outputs_both, n_outputs_closed
-
-
-def save_as_jsonl(output_path: str, iterable: List[Dict]):
-    """Save a list of dicts to JSON Lines format.
-
-    :param output_path: the file path.
-    :param iterable: the objects to save.
-    :return: None.
-    """
-
-    with open(output_path, "w") as f:
-        with jsonlines.Writer(f) as writer:
-            writer.write_all(iterable)
 
 
 class OaWebRelease(SnapshotRelease):

--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -103,10 +103,10 @@ is licenced under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 
 ## Attributions
 This work contains information from:
-* [Microsoft Academic Graph](https://www.microsoft.com/en-us/research/project/microsoft-academic-graph/) which is made available under the [ODC Attribution License](https://opendatacommons.org/licenses/by/1-0/)
-* [Crossref Metadata](https://www.crossref.org/documentation/metadata-plus/) via the Metadata Plus program. Bibliographic metadata is made available without copyright restriction and Crossref generated data with a CC0 licence. See [metadata licence information](https://www.crossref.org/documentation/retrieve-metadata/rest-api/rest-api-metadata-license-information/) for more details.
-* [Unpaywall](https://unpaywall.org/products/data-feed) which is made available under a CC0 licence.
-* [Research Organization Registry](https://ror.org/) which is made available under a CC0 licence.
+* [Microsoft Academic Graph](https://www.microsoft.com/en-us/research/project/microsoft-academic-graph/) which is made available under the [ODC Attribution License](https://opendatacommons.org/licenses/by/1-0/).
+* [Crossref Metadata](https://www.crossref.org/documentation/metadata-plus/) via the Metadata Plus program. Bibliographic metadata is made available without copyright restriction and Crossref generated data with a [CC0 licence](https://creativecommons.org/share-your-work/public-domain/cc0/). See [metadata licence information](https://www.crossref.org/documentation/retrieve-metadata/rest-api/rest-api-metadata-license-information/) for more details.
+* [Unpaywall](https://unpaywall.org/products/data-feed) which is made available under a [CC0 licence](https://creativecommons.org/share-your-work/public-domain/cc0/).
+* [Research Organization Registry](https://ror.org/) which is made available under a [CC0 licence](https://creativecommons.org/share-your-work/public-domain/cc0/).
 """
 
 

--- a/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
@@ -47,8 +47,8 @@ from academic_observatory_workflows.workflows.oa_web_workflow import (
     remove_text_between_brackets,
     shorten_text_full_sentences,
     split_largest_remainder,
-    val_empty,
     trigger_repository_dispatch,
+    val_empty,
 )
 from observatory.platform.utils.file_utils import load_jsonl
 from observatory.platform.utils.test_utils import (
@@ -264,9 +264,10 @@ class TestFunctions(TestCase):
 
 class TestOaWebRelease(TestCase):
     maxDiff = None
+    dt_fmt = "YYYY-MM-DD"
 
     def setUp(self) -> None:
-        dt_fmt = "YYYY-MM-DD"
+
         self.release = OaWebRelease(
             dag_id="dag", project_id="project", release_date=pendulum.now(), data_bucket_name="data-bucket-name"
         )
@@ -276,7 +277,7 @@ class TestOaWebRelease(TestCase):
                 "id": "NZL",
                 "name": "New Zealand",
                 "year": 2020,
-                "date": pendulum.date(2020, 12, 31).format(dt_fmt),
+                "date": pendulum.date(2020, 12, 31).format(self.dt_fmt),
                 "url": None,
                 "wikipedia_url": "https://en.wikipedia.org/wiki/New_Zealand",
                 "country": None,
@@ -302,7 +303,7 @@ class TestOaWebRelease(TestCase):
                 "id": "NZL",
                 "name": "New Zealand",
                 "year": 2021,
-                "date": pendulum.date(2021, 12, 31).format(dt_fmt),
+                "date": pendulum.date(2021, 12, 31).format(self.dt_fmt),
                 "url": None,
                 "wikipedia_url": "https://en.wikipedia.org/wiki/New_Zealand",
                 "country": None,
@@ -330,7 +331,7 @@ class TestOaWebRelease(TestCase):
                 "id": "https://ror.org/02n415q13",
                 "name": "Curtin University",
                 "year": 2020,
-                "date": pendulum.date(2020, 12, 31).format(dt_fmt),
+                "date": pendulum.date(2020, 12, 31).format(self.dt_fmt),
                 "url": "https://curtin.edu.au/",
                 "wikipedia_url": "https://en.wikipedia.org/wiki/Curtin_University",
                 "country": "Australia",
@@ -362,7 +363,7 @@ class TestOaWebRelease(TestCase):
                 "id": "https://ror.org/02n415q13",
                 "name": "Curtin University",
                 "year": 2021,
-                "date": pendulum.date(2021, 12, 31).format(dt_fmt),
+                "date": pendulum.date(2021, 12, 31).format(self.dt_fmt),
                 "url": "https://curtin.edu.au/",
                 "wikipedia_url": "https://en.wikipedia.org/wiki/Curtin_University",
                 "country": "Australia",
@@ -380,38 +381,6 @@ class TestOaWebRelease(TestCase):
                 # "n_outputs_closed": 55,
                 "n_outputs_oa_journal": 20,
                 "n_outputs_hybrid": 9,
-                "n_outputs_no_guarantees": 8,
-                "identifiers": {
-                    "ISNI": {"all": ["0000 0004 0375 4078"]},
-                    "OrgRef": {"all": ["370725"]},
-                    "Wikidata": {"all": ["Q1145497"]},
-                    "GRID": {"preferred": "grid.1032.0"},
-                    "FundRef": {"all": ["501100001797"]},
-                },
-            },
-            {
-                "alpha2": None,
-                "id": "https://ror.org/12345",
-                "name": "Foo University",
-                "year": 2020,
-                "date": pendulum.date(2020, 12, 31).format(dt_fmt),
-                "url": None,
-                "wikipedia_url": None,
-                "country": "Australia",
-                "subregion": "Australia and New Zealand",
-                "region": "Oceania",
-                "institution_types": ["Education"],
-                "n_citations": 121,
-                "n_outputs": 100,
-                "n_outputs_open": 48,
-                "n_outputs_publisher_open": 37,
-                # "n_outputs_publisher_open_only": 11,
-                # "n_outputs_both": 26,
-                "n_outputs_other_platform_open": 37,
-                "n_outputs_other_platform_open_only": 11,
-                # "n_outputs_closed": 52,
-                "n_outputs_oa_journal": 19,
-                "n_outputs_hybrid": 10,
                 "n_outputs_no_guarantees": 8,
                 "identifiers": {
                     "ISNI": {"all": ["0000 0004 0375 4078"]},
@@ -595,7 +564,41 @@ class TestOaWebRelease(TestCase):
 
             # Institution table
             category = "institution"
-            df = pd.DataFrame(self.institutions)
+            institutions = self.institutions + [
+                {
+                    "alpha2": None,
+                    "id": "https://ror.org/12345",
+                    "name": "Foo University",
+                    "year": 2020,
+                    "date": pendulum.date(2020, 12, 31).format(self.dt_fmt),
+                    "url": None,
+                    "wikipedia_url": None,
+                    "country": "Australia",
+                    "subregion": "Australia and New Zealand",
+                    "region": "Oceania",
+                    "institution_types": ["Education"],
+                    "n_citations": 121,
+                    "n_outputs": 100,
+                    "n_outputs_open": 48,
+                    "n_outputs_publisher_open": 37,
+                    # "n_outputs_publisher_open_only": 11,
+                    # "n_outputs_both": 26,
+                    "n_outputs_other_platform_open": 37,
+                    "n_outputs_other_platform_open_only": 11,
+                    # "n_outputs_closed": 52,
+                    "n_outputs_oa_journal": 19,
+                    "n_outputs_hybrid": 10,
+                    "n_outputs_no_guarantees": 8,
+                    "identifiers": {
+                        "ISNI": {"all": ["0000 0004 0375 4078"]},
+                        "OrgRef": {"all": ["370725"]},
+                        "Wikidata": {"all": ["Q1145497"]},
+                        "GRID": {"preferred": "grid.1032.0"},
+                        "FundRef": {"all": ["501100001797"]},
+                    },
+                },
+            ]
+            df = pd.DataFrame(institutions)
             df = self.release.preprocess_df(category, df)
             df_index_table = self.release.make_index(category, df)
             with vcr.use_cassette(test_fixtures_folder("oa_web_workflow", "test_make_logos.yaml")):
@@ -627,11 +630,13 @@ class TestOaWebRelease(TestCase):
             for category, data, entity_ids in self.entities:
                 df = pd.DataFrame(data)
                 df = self.release.preprocess_df(category, df)
-                country_index = self.release.make_index(category, df)
-                self.release.update_index_with_logos(category, country_index)
-                self.release.save_index(category, country_index)
+                df_index_table = self.release.make_index(category, df)
+                self.release.update_index_with_logos(category, df_index_table)
+                entities = self.release.make_entities(df_index_table, df)
+                file_name = f"{category}.json"
+                self.release.save_index(entities, file_name)
 
-                path = os.path.join(self.release.build_path, "data", f"{category}.json")
+                path = os.path.join(self.release.build_path, "data", file_name)
                 self.assertTrue(os.path.isfile(path))
 
     @patch("academic_observatory_workflows.workflows.oa_web_workflow.Variable.get")
@@ -659,8 +664,8 @@ class TestOaWebRelease(TestCase):
                     "wikipedia_url": "https://en.wikipedia.org/wiki/New_Zealand",
                     "subregion": "Australia and New Zealand",
                     "region": "Oceania",
-                    "max_year": 2021,
-                    "min_year": 2020,
+                    "end_year": 2021,
+                    "start_year": 2020,
                     "stats": {
                         "n_citations": 354,
                         "n_outputs": 200,
@@ -685,7 +690,7 @@ class TestOaWebRelease(TestCase):
                         "p_outputs_hybrid": 26.0,
                         "p_outputs_no_guarantees": 21.0,
                     },
-                    "timeseries": [
+                    "years": [
                         {
                             "year": 2020,
                             "date": "2020-12-31",
@@ -746,8 +751,9 @@ class TestOaWebRelease(TestCase):
                 }
             ]
 
-            for a_entity, e_entity in zip(expected, entities):
-                self.assertDictEqual(a_entity, e_entity.to_dict())
+            for e_dict, a_entity in zip(expected, entities):
+                a_dict = a_entity.to_dict()
+                self.assertDictEqual(e_dict, a_dict)
 
         # Institution
         category = "institution"
@@ -772,8 +778,8 @@ class TestOaWebRelease(TestCase):
                 "subregion": "Australia and New Zealand",
                 "region": "Oceania",
                 "institution_types": ["Education"],
-                "max_year": 2021,
-                "min_year": 2020,
+                "end_year": 2021,
+                "start_year": 2020,
                 "identifiers": [
                     {"type": "ROR", "id": "02n415q13", "url": "https://ror.org/02n415q13"},
                     {"type": "ISNI", "id": "0000 0004 0375 4078", "url": "https://isni.org/isni/0000 0004 0375 4078"},
@@ -805,7 +811,7 @@ class TestOaWebRelease(TestCase):
                     "p_outputs_hybrid": 26.0,
                     "p_outputs_no_guarantees": 21.0,
                 },
-                "timeseries": [
+                "years": [
                     {
                         "year": 2020,
                         "date": "2020-12-31",
@@ -866,8 +872,9 @@ class TestOaWebRelease(TestCase):
             }
         ]
 
-        for a_entity, e_entity in zip(expected, entities):
-            self.assertDictEqual(a_entity, e_entity.to_dict())
+        for e_dict, a_entity in zip(expected, entities):
+            a_dict = a_entity.to_dict()
+            self.assertDictEqual(e_dict, a_dict)
 
     @patch("academic_observatory_workflows.workflows.oa_web_workflow.Variable.get")
     def test_save_entities(self, mock_var_get):
@@ -1072,10 +1079,12 @@ class TestOaWebWorkflow(ObservatoryTestCase):
                     print(f"\t{file}")
                     self.assertTrue(os.path.isfile(file))
 
-                # Check that zip file exists
-                latest_file = os.path.join(base_folder, "latest.zip")
-                print(f"\t{latest_file}")
-                self.assertTrue(os.path.isfile(latest_file))
+                # Check that full dataset zip file exists
+                archives = ["latest.zip", "coki-oa-dataset.zip"]
+                for file_name in archives:
+                    latest_file = os.path.join(base_folder, file_name)
+                    print(f"\t{latest_file}")
+                    self.assertTrue(os.path.isfile(latest_file))
 
                 # Upload data to bucket
                 ti = env.run_task(workflow.upload_dataset.__name__)
@@ -1109,15 +1118,7 @@ def make_expected_build_files(base_path: str) -> List[str]:
 
     # Add base data files
     data_path = os.path.join(base_path, "data")
-    file_names = [
-        "stats.json",
-        "autocomplete.json",
-        "autocomplete.parquet",
-        "country.json",
-        "country.parquet",
-        "institution.json",
-        "institution.parquet",
-    ]
+    file_names = ["stats.json", "autocomplete.json", "country.json", "institution.json", "index.json"]
     for file_name in file_names:
         expected.append(os.path.join(data_path, file_name))
 

--- a/docs/workflows/oa_web.md
+++ b/docs/workflows/oa_web.md
@@ -21,8 +21,8 @@ The figure below illustrates the generated data and notes about what each file i
 ```
     .
     ├── data: data
+    │   ├── index.json: used by the Cloudflare Worker search and filtering API.
     │   ├── autocomplete.json: used for the website search functionality. Copied into public/data folder.
-    │   ├── autocomplete.parquet: used for filtering in Cloudflare Worker.
     │   ├── country: individual entity statistics files for countries. Used to build each country page.
     │   │   ├── ALB.json
     │   │   ├── ARE.json
@@ -30,8 +30,6 @@ The figure below illustrates the generated data and notes about what each file i
     │   ├── country.json: used to create the country table. First 18 countries used to build first page of country table
     │   │                 and then this file is included in the public folder and downloaded by the client to enable the
     │   │                 other pages of the table to be displayed. Copied into public/data folder.
-    │   ├── country.jsonl: used to generate the parquet file.
-    │   ├── country.parquet: to be used along with apache-arrow to enable filtering from a Cloudflare Worker.
     │   ├── institution: individual entity statistics files for institutions. Used to build each institution page.
     │   │   ├── 05ykr0121.json
     │   │   ├── 05ym42410.json
@@ -39,8 +37,6 @@ The figure below illustrates the generated data and notes about what each file i
     │   ├── institution.json: used to create the institution table. First 18 institutions used to build first page of institution table
     │   │                     and then this file is included in the public folder and downloaded by the client to enable the
     │   │                     other pages of the table to be displayed. Copied into public/data folder.
-    │   ├── institution.jsonl: used to generate the parquet file.
-    │   ├── institution.parquet: to be used along with apache-arrow to enable filtering from a Cloudflare Worker.
     │   └── stats.json: global statistics, e.g. the minimum and maximum date for the dataset, when it was last updated etc.
     └── logos: country and institution logos. Copied into public/logos folder.
         ├── country

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ beautifulsoup4>=4.9.3,<5
 boto3>=1.15.0,<2
 pyarrow>=6,<7
 nltk==3.*
+Deprecated>1,<2


### PR DESCRIPTION
* Save a JSON index designed for the Cloudflare Worker filtering API. The file includes all countries and institutions and only saves the fields that are necessary to display in the tables and for filtering. The same code has also been used to save country.json and institution.json, which are currently loaded by the client and used to populate the tables.
* Updates for releasing the open source version of the dataset:
  *  Save the open access version of the dataset, a zip file with country.jsonl, institution.jsonl and README.
  * Changed min_year and max_year to start_year and end_year.
  * Changed timeseries to years.
  * Incremented dataset version number so that these changes won't break the web application.
* Removed code that isn't currently used, e.g. Subject, Collaborator.
* Removed parquet saving as this is no longer necessary.