### PR TITLE
Fix error getting wiki description oa_web_workflow

### DIFF
--- a/academic_observatory_workflows/fixtures/oa_web_workflow/institution_wiki_response.json
+++ b/academic_observatory_workflows/fixtures/oa_web_workflow/institution_wiki_response.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83b91837fbfbb8bec04636899c29e0ed6840ec90c01a00c047f5a0149396afe4
-size 22682
+oid sha256:26f6c3a4c2f1dec90295dcbbed2bf666aa1c9be8f3bc195c0232e6bbcb76dcef
+size 22830


### PR DESCRIPTION
I have updated the way that the page titles returned by the Wikipedia API are returned match the page titles that are originally retrieved from the wikipedia_url.

This should fix the KeyError that occurred in the JIRA ticket described here https://curtinic.atlassian.net/browse/INF-353