### PR TITLE
Fix error for Orcid telescope

### DIFF
--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -169,7 +169,9 @@ class OrcidRelease(StreamRelease):
                 f"gs://{gc_download_bucket}",
                 self.download_folder,
             ]
-            proc: Popen = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc: Popen = subprocess.Popen(
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=dict(os.environ, CLOUDSDK_PYTHON="python3")
+            )
         else:
             # Download only modified records from bucket
             write_modified_record_blobs(
@@ -182,7 +184,11 @@ class OrcidRelease(StreamRelease):
             )
             args = ["gsutil", "-m", "-q", "cp", "-L", log_path, "-I", self.download_folder]
             proc: Popen = subprocess.Popen(
-                args, stdin=open(self.modified_records_path), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                args,
+                stdin=open(self.modified_records_path),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=dict(os.environ, CLOUDSDK_PYTHON="python3"),
             )
         run_subprocess_cmd(proc, args)
 

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -459,6 +459,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
             ],
             stdout=-1,
             stderr=-1,
+            env=dict({"GOOGLE_APPLICATION_CREDENTIALS": "credentials.json"}, CLOUDSDK_PYTHON="python3"),
         )
 
         # Test download in case of second release, using modified records file
@@ -502,6 +503,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
                 stdin=ANY,
                 stdout=-1,
                 stderr=-1,
+                env=dict({"GOOGLE_APPLICATION_CREDENTIALS": "credentials.json"}, CLOUDSDK_PYTHON="python3"),
             )
             self.assertEqual(self.release.modified_records_path, mock_subprocess.call_args[1]["stdin"].name)
 


### PR DESCRIPTION
Use gcloud fix for gsutil command as well. gsutil ran without issues until last week, using the same fix as for the gcloud command solves the problem.