### PR TITLE
Rename 'metrics_green_only' to 'metrics_percent_green_only'

### DIFF
--- a/academic_observatory_workflows/database/sql/export_metrics.sql.jinja2
+++ b/academic_observatory_workflows/database/sql/export_metrics.sql.jinja2
@@ -26,7 +26,7 @@ SELECT
   access_types.gold_doaj.total_outputs as metrics_num_gold_doaj_outputs,
   access_types.oa.percent AS metrics_percent_oa,
   access_types.green.percent as metrics_percent_green,
-  access_types.green_only.percent as metrics_green_only,
+  access_types.green_only.percent as metrics_percent_green_only,
   access_types.gold.percent as metrics_percent_gold,
   access_types.gold_doaj.percent as metrics_percent_gold_doaj,
   access_types.hybrid.percent as metrics_percent_hybrid,


### PR DESCRIPTION
Rename 'metrics_green_only' to 'metrics_percent_green_only' for data export tables, this matches with the other fields and the corresponding field in the elasticsearch mapping.

This should fix the elastic import error, because there is no 'metrics_green_only' field in the elasticsearch mappings, it had to guess the value type and this caused an error.