### PR TITLE
Fix/api update

### DIFF
--- a/academic_observatory_workflows/dags/crossref_events_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_events_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=CrossrefEventsTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = CrossrefEventsTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = CrossrefEventsTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_fundref_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=CrossrefFundrefTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = CrossrefFundrefTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = CrossrefFundrefTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/dags/crossref_metadata_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=CrossrefMetadataTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = CrossrefMetadataTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = CrossrefMetadataTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/doi_workflow.py
+++ b/academic_observatory_workflows/dags/doi_workflow.py
@@ -49,6 +49,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=DoiWorkflow.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-doi_workflow = DoiWorkflow(workflow_id=workflows[0].id)
-globals()[doi_workflow.dag_id] = doi_workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    doi_workflow = DoiWorkflow(workflow_id=workflows[0].id)
+    globals()[doi_workflow.dag_id] = doi_workflow.make_dag()

--- a/academic_observatory_workflows/dags/geonames_telescope.py
+++ b/academic_observatory_workflows/dags/geonames_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=GeonamesTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = GeonamesTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = GeonamesTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/grid_telescope.py
+++ b/academic_observatory_workflows/dags/grid_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=GridTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = GridTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = GridTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/open_citations_telescope.py
+++ b/academic_observatory_workflows/dags/open_citations_telescope.py
@@ -31,6 +31,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=OpenCitationsTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = OpenCitationsTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = OpenCitationsTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/openalex_telescope.py
+++ b/academic_observatory_workflows/dags/openalex_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=OpenAlexTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = OpenAlexTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = OpenAlexTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/orcid_telescope.py
+++ b/academic_observatory_workflows/dags/orcid_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=OrcidTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = OrcidTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = OrcidTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/ror_telescope.py
+++ b/academic_observatory_workflows/dags/ror_telescope.py
@@ -23,6 +23,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=RorTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-workflow = RorTelescope(workflow_id=workflows[0].id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = RorTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/scopus_telescope.py
+++ b/academic_observatory_workflows/dags/scopus_telescope.py
@@ -26,20 +26,19 @@ from observatory.platform.utils.workflow_utils import make_dag_id
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=ScopusTelescope.DAG_ID)
 workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-dataset_type = api.get_dataset_type(type_id="scopus")
 
 # Create workflows for each organisation
 for workflow in workflows:
     dag_id = make_dag_id(ScopusTelescope.DAG_ID, workflow.organisation.name)
-    airflow_conns = dataset_type.extra.get("airflow_connections")
-    institution_ids = dataset_type.extra.get("institution_ids")
-    view = dataset_type.extra.get("view")
+    airflow_conns = workflow.extra.get("airflow_connections")
+    institution_ids = workflow.extra.get("institution_ids")
+    view = workflow.extra.get("view")
 
     if airflow_conns is None or institution_ids is None or view is None:
         raise Exception(f"airflow_conns: {airflow_conns} or institution_ids: {institution_ids} or view: {view} is None")
 
     # earliest_date is parsed into a datetime.date object by the Python API client
-    earliest_date_str = dataset_type.extra.get("earliest_date")
+    earliest_date_str = workflow.extra.get("earliest_date")
     earliest_date = pendulum.parse(earliest_date_str)
 
     airflow_vars = [

--- a/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_snapshot_telescope.py
@@ -36,10 +36,7 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=UnpaywallSnapshotTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-
-# Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
-workflow = workflows[0]
-
-workflow = UnpaywallSnapshotTelescope(workflow_id=workflow.id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    workflow = UnpaywallSnapshotTelescope(workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/dags/unpaywall_telescope.py
+++ b/academic_observatory_workflows/dags/unpaywall_telescope.py
@@ -27,11 +27,8 @@ from observatory.platform.utils.api import make_observatory_api
 
 api = make_observatory_api()
 workflow_type = api.get_workflow_type(type_id=UnpaywallTelescope.DAG_ID)
-workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1000)
-
-# Better to throw error here. If setting up for multi instance, then need to standardise dag_id etc.
-workflow = workflows[0]
-
-start_date = pendulum.datetime(2021, 10, 18)  # Set this to the snapshot release date you want to base it off
-workflow = UnpaywallTelescope(start_date=start_date, workflow_id=workflow.id)
-globals()[workflow.dag_id] = workflow.make_dag()
+workflows = api.get_workflows(workflow_type_id=workflow_type.id, limit=1)
+if len(workflows):
+    start_date = pendulum.datetime(2021, 10, 18)  # Set this to the snapshot release date you want to base it off
+    workflow = UnpaywallTelescope(start_date=start_date, workflow_id=workflows[0].id)
+    globals()[workflow.dag_id] = workflow.make_dag()

--- a/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_fundref_telescope.py
@@ -30,11 +30,12 @@ from typing import Dict, List, Tuple
 import jsonlines
 import pendulum
 import requests
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.api.common.experimental.pool import create_pool
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.variable import Variable
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -35,6 +35,8 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from bs4 import BeautifulSoup
 from natsort import natsorted
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.url_utils import retry_session
@@ -43,8 +45,6 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class CrossrefMetadataRelease(SnapshotRelease):

--- a/academic_observatory_workflows/workflows/geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/geonames_telescope.py
@@ -26,9 +26,10 @@ from zipfile import ZipFile
 
 import pendulum
 import requests
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.http_download import download_file
 from observatory.platform.workflows.snapshot_telescope import (

--- a/academic_observatory_workflows/workflows/grid_telescope.py
+++ b/academic_observatory_workflows/workflows/grid_telescope.py
@@ -25,10 +25,11 @@ from typing import List
 from zipfile import BadZipFile, ZipFile
 
 import pendulum
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
 from observatory.platform.utils.http_download import download_file

--- a/academic_observatory_workflows/workflows/mag_telescope.py
+++ b/academic_observatory_workflows/workflows/mag_telescope.py
@@ -26,7 +26,6 @@ from subprocess import Popen
 from typing import List
 
 import pendulum
-from academic_observatory_workflows.config import schema_folder
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models.taskinstance import TaskInstance
@@ -35,8 +34,9 @@ from google.cloud import storage
 from google.cloud.bigquery import SourceFormat
 from google.cloud.storage import Blob
 from natsort import natsorted
+
+from academic_observatory_workflows.config import schema_folder
 from observatory.platform.utils.airflow_utils import (
-    AirflowConns,
     AirflowVars,
     check_connections,
     check_variables,
@@ -58,7 +58,6 @@ from observatory.platform.utils.workflow_utils import (
     delete_old_xcoms,
     workflow_path,
 )
-from sqlalchemy.sql.expression import delete
 
 MAG_GCP_BUCKET_PATH = "telescopes/mag"
 

--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -38,7 +38,6 @@ import requests
 from airflow.exceptions import AirflowException
 from airflow.models.variable import Variable
 from airflow.sensors.external_task import ExternalTaskSensor
-from deprecated import deprecated
 from jinja2 import Template
 
 from academic_observatory_workflows.clearbit import clearbit_download_logo
@@ -426,7 +425,7 @@ class Entity:
             end_year=end_year,
             institution_types=institution_types,
             identifiers=identifiers,
-            acronyms=acronyms
+            acronyms=acronyms,
         )
 
     def to_dict(self) -> Dict:

--- a/academic_observatory_workflows/workflows/open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/open_citations_telescope.py
@@ -19,11 +19,12 @@ import zipfile
 from typing import Dict, List
 
 import pendulum
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.models import Variable
 from airflow.models.taskinstance import TaskInstance
 from google.cloud import bigquery
 from google.cloud.bigquery import SourceFormat
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import (
     bigquery_sharded_table_id,

--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -32,6 +32,8 @@ from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.hooks.base import BaseHook
 from airflow.models.variable import Variable
 from google.cloud import storage
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import aws_to_google_cloud_storage_transfer
 from observatory.platform.utils.proc_utils import wait_for_process
@@ -39,8 +41,6 @@ from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,
 )
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class OpenAlexRelease(StreamRelease):

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -33,8 +33,9 @@ import pendulum
 import xmltodict
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.hooks.base_hook import BaseHook
-from airflow.models.taskinstance import TaskInstance
 from airflow.models.variable import Variable
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import (
@@ -46,8 +47,6 @@ from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,
 )
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class OrcidRelease(StreamRelease):

--- a/academic_observatory_workflows/workflows/ror_telescope.py
+++ b/academic_observatory_workflows/workflows/ror_telescope.py
@@ -28,6 +28,8 @@ import requests
 from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from google.cloud.bigquery import SourceFormat
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.file_utils import list_to_jsonl_gz
 from observatory.platform.utils.url_utils import (
@@ -37,8 +39,6 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class RorRelease(SnapshotRelease):

--- a/academic_observatory_workflows/workflows/scopus_telescope.py
+++ b/academic_observatory_workflows/workflows/scopus_telescope.py
@@ -29,9 +29,11 @@ from urllib.parse import quote_plus
 
 import jsonlines
 import pendulum
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow import AirflowException
 from google.cloud.bigquery import WriteDisposition
+from ratelimit import limits, sleep_and_retry
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import (
     AirflowConns,
     AirflowVars,
@@ -50,7 +52,6 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
-from ratelimit import limits, sleep_and_retry
 
 
 class ScopusRelease(SnapshotRelease):

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -15,11 +15,16 @@
 # Author: Aniek Roelofs
 
 import os
-from datetime import timedelta
 from unittest.mock import patch
 
 import pendulum
 import vcr
+from airflow.exceptions import AirflowSkipException
+from airflow.models import Connection
+from airflow.utils.state import State
+from click.testing import CliRunner
+from google.cloud import bigquery
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.crossref_events_telescope import (
     CrossrefEventsRelease,
@@ -27,9 +32,17 @@ from academic_observatory_workflows.workflows.crossref_events_telescope import (
     parse_event_url,
     transform_batch,
 )
-from airflow.exceptions import AirflowSkipException
-from click.testing import CliRunner
-from google.cloud import bigquery
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -37,20 +50,6 @@ from observatory.platform.utils.test_utils import (
 )
 from observatory.platform.utils.url_utils import get_user_agent
 from observatory.platform.utils.workflow_utils import blob_name, create_date_table_id
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestCrossrefEventsTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_fundref_telescope.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import httpretty
 import pendulum
 import vcr
+from airflow.models import Connection
 from airflow.utils.state import State
 from click.testing import CliRunner
 
@@ -31,7 +32,18 @@ from academic_observatory_workflows.workflows.crossref_fundref_telescope import 
     list_releases,
     strip_whitespace,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import get_file_hash
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -41,20 +53,6 @@ from observatory.platform.utils.workflow_utils import (
     bigquery_sharded_table_id,
     blob_name,
 )
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestCrossrefFundrefTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -22,7 +22,8 @@ from unittest.mock import patch
 import httpretty
 import pendulum
 from airflow.exceptions import AirflowException
-from airflow.models.connection import Connection
+from airflow.models import Connection
+from airflow.utils.state import State
 from click.testing import CliRunner
 from natsort import natsorted
 
@@ -33,28 +34,25 @@ from academic_observatory_workflows.workflows.crossref_metadata_telescope import
     transform_item,
     transform_file,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import load_jsonl
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
 )
 from observatory.platform.utils.workflow_utils import blob_name
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestCrossrefMetadataTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -23,6 +23,8 @@ from unittest.mock import patch
 
 import pendulum
 from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.utils.state import State
 
 from academic_observatory_workflows.model import (
     Institution,
@@ -37,28 +39,25 @@ from academic_observatory_workflows.workflows.doi_workflow import (
     make_dataset_transforms,
     make_elastic_tables,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.airflow_utils import set_task_state
 from observatory.platform.utils.gc_utils import run_bigquery_query
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     make_dummy_dag,
     module_file_path,
 )
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestDoiWorkflow(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_geonames_telescope.py
@@ -18,6 +18,8 @@ import os
 from unittest.mock import patch
 
 import pendulum
+from airflow.models import Connection
+from airflow.utils.state import State
 
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.geonames_telescope import (
@@ -26,8 +28,19 @@ from academic_observatory_workflows.workflows.geonames_telescope import (
     fetch_release_date,
     first_sunday_of_month,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import get_file_hash
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     HttpServer,
     ObservatoryEnvironment,
@@ -36,24 +49,9 @@ from observatory.platform.utils.test_utils import (
 )
 from observatory.platform.utils.workflow_utils import (
     SubFolder,
-    blob_name,
     workflow_path,
 )
-from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
 from observatory.platform.utils.workflow_utils import blob_name
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class MockResponse:

--- a/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_grid_telescope.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pendulum
 from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.utils.state import State
 from click.testing import CliRunner
 
 from academic_observatory_workflows.config import test_fixtures_folder
@@ -31,28 +33,26 @@ from academic_observatory_workflows.workflows.grid_telescope import (
     GridTelescope,
     list_grid_records,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import get_file_hash, gzip_file_crc
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     HttpServer,
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
 )
-from observatory.platform.utils.workflow_utils import blob_name, table_ids_from_path
 from observatory.platform.utils.workflow_utils import blob_name
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
+from observatory.platform.utils.workflow_utils import table_ids_from_path
 
 
 class MockResponse:

--- a/academic_observatory_workflows/workflows/tests/test_mag_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_mag_telescope.py
@@ -22,6 +22,10 @@ from zipfile import ZipFile
 
 import natsort
 import pendulum
+from click.testing import CliRunner
+from google.cloud import bigquery, storage
+from google.cloud.storage import Blob
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.mag_telescope import (
     MagTelescope,
@@ -30,9 +34,6 @@ from academic_observatory_workflows.workflows.mag_telescope import (
     transform_mag_file,
     transform_mag_release,
 )
-from click.testing import CliRunner
-from google.cloud import bigquery, storage
-from google.cloud.storage import Blob
 from observatory.platform.utils.gc_utils import upload_files_to_cloud_storage
 from observatory.platform.utils.test_utils import ObservatoryTestCase, random_id
 

--- a/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
@@ -119,7 +119,7 @@ class MockZenodo(Zenodo):
             "state": "unsubmitted",
             "created": "2022-04-25T22:16:16.145039+00:00",
             "files": [{"id": "596c128f-d240-4008-87b6-cecf143e9d48"}],
-            "metadata": {}
+            "metadata": {},
         }
         return res
 

--- a/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_open_citations_telescope.py
@@ -15,20 +15,31 @@
 # Author: James Diprose, Tuan Chien
 
 import os
-import unittest
-from re import template
 from unittest.mock import MagicMock, patch
 
 import pendulum
+from airflow.models import Connection
+from airflow.utils.state import State
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.open_citations_telescope import (
     OpenCitationsRelease,
     OpenCitationsTelescope,
 )
-from airflow.utils.state import State
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.gc_utils import run_bigquery_query
 from observatory.platform.utils.http_download import DownloadInfo
 from observatory.platform.utils.jinja2_utils import render_template
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     HttpServer,
     ObservatoryEnvironment,
@@ -37,22 +48,8 @@ from observatory.platform.utils.test_utils import (
 )
 from observatory.platform.utils.workflow_utils import (
     bigquery_sharded_table_id,
-    blob_name,
 )
 from observatory.platform.utils.workflow_utils import blob_name
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestOpenCitationsTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -14,29 +14,20 @@
 
 # Author: Aniek Roelofs
 
+import datetime
 import gzip
 import io
 import json
 import os
-import datetime
-from datetime import timedelta
 from subprocess import Popen
 from unittest.mock import Mock, call, patch
 
 import pendulum
 from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.models.connection import Connection
+from airflow.models import Connection
+from airflow.utils.state import State
 from botocore.response import StreamingBody
 from click.testing import CliRunner
-from observatory.platform.utils.gc_utils import (
-    upload_file_to_cloud_storage,
-)
-from observatory.platform.utils.jinja2_utils import render_template
-from observatory.platform.utils.test_utils import (
-    ObservatoryEnvironment,
-    ObservatoryTestCase,
-    module_file_path,
-)
 
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.openalex_telescope import (
@@ -46,20 +37,26 @@ from academic_observatory_workflows.workflows.openalex_telescope import (
     transform_file,
     transform_object,
 )
-from observatory.platform.utils.workflow_utils import blob_name
-from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.client.model.dataset import Dataset
 from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
 from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
+from observatory.platform.utils.gc_utils import (
+    upload_file_to_cloud_storage,
+)
+from observatory.platform.utils.jinja2_utils import render_template
+from observatory.platform.utils.release_utils import get_dataset_releases
+from observatory.platform.utils.test_utils import (
+    ObservatoryEnvironment,
+    ObservatoryTestCase,
+    module_file_path,
+)
 
 
 class TestOpenAlexTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -14,50 +14,49 @@
 
 # Author: Aniek Roelofs
 
+import datetime
 import gzip
 import io
 import os
-import datetime
-from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import ANY, patch
 
 import pendulum
+from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.models import Connection
+from airflow.models.variable import Variable
+from airflow.utils.state import State
+from botocore.response import StreamingBody
+from click.testing import CliRunner
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.orcid_telescope import (
     OrcidRelease,
     OrcidTelescope,
     transform_single_file,
 )
-from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.models.connection import Connection
-from airflow.models.variable import Variable
-from botocore.response import StreamingBody
-from click.testing import CliRunner
-from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars, BaseHook
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
+from observatory.platform.utils.airflow_utils import AirflowVars, BaseHook
 from observatory.platform.utils.gc_utils import (
     upload_file_to_cloud_storage,
     upload_files_to_cloud_storage,
 )
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
     module_file_path,
 )
 from observatory.platform.utils.workflow_utils import blob_name
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestOrcidTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -15,21 +15,35 @@
 # Author: Aniek Roelofs
 
 import json
-import jsonlines
 import os
-import httpretty
-import pendulum
 from unittest.mock import patch
 
-from click.testing import CliRunner
+import httpretty
+import jsonlines
+import pendulum
 from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.utils.state import State
+from click.testing import CliRunner
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.ror_telescope import (
     RorRelease,
     RorTelescope,
     list_ror_records,
 )
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.gc_utils import bigquery_sharded_table_id
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -38,19 +52,6 @@ from observatory.platform.utils.test_utils import (
 from observatory.platform.utils.workflow_utils import (
     blob_name,
 )
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.release_utils import get_dataset_releases
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
-from airflow.utils.state import State
 
 
 class TestRorTelescope(ObservatoryTestCase):

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -14,22 +14,33 @@
 
 # Author: Tuan Chien
 
-from gc import freeze
 import os
 import shutil
 import unittest
 from unittest.mock import patch
 
 import pendulum
+from airflow.models import Connection
+from airflow.utils.state import State
+from click.testing import CliRunner
+from google.cloud import bigquery
+
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.unpaywall_telescope import (
     UnpaywallRelease,
     UnpaywallTelescope,
 )
-from airflow.models.connection import Connection
-from airflow.utils.state import State
-from click.testing import CliRunner
-from google.cloud import bigquery
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_release import DatasetRelease
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
+from observatory.api.testing import ObservatoryApiEnvironment
+from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import validate_file_hash
 from observatory.platform.utils.jinja2_utils import render_template
 from observatory.platform.utils.release_utils import get_dataset_releases, get_latest_dataset_release
@@ -40,18 +51,6 @@ from observatory.platform.utils.test_utils import (
     module_file_path,
 )
 from observatory.platform.utils.workflow_utils import blob_name, create_date_table_id
-from observatory.api.testing import ObservatoryApiEnvironment
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_release import DatasetRelease
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.table_type import TableType
-from observatory.platform.utils.airflow_utils import AirflowConns
-from airflow.models import Connection
 
 
 class TestUnpaywallRelease(unittest.TestCase):

--- a/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_web_of_science_telescope.py
@@ -16,15 +16,19 @@
 
 
 import json
-import logging
 import os
 import unittest
 from collections import OrderedDict
 from typing import OrderedDict
 from unittest.mock import MagicMock, call, patch
 
-import observatory.api.server.orm as orm
 import pendulum
+from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.utils.state import State
+from click.testing import CliRunner
+
+import observatory.api.server.orm as orm
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.web_of_science_telescope import (
     WebOfScienceRelease,
@@ -34,13 +38,12 @@ from academic_observatory_workflows.workflows.web_of_science_telescope import (
     WosUtilConst,
     WosUtility,
 )
-from airflow.exceptions import AirflowException
-from airflow.models import Connection
-from airflow.utils.state import State
-from click.testing import CliRunner
+from observatory.api.client import ApiClient, Configuration
+from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
 from observatory.platform.utils.airflow_utils import AirflowConns, AirflowVars
 from observatory.platform.utils.api import make_observatory_api
 from observatory.platform.utils.gc_utils import run_bigquery_query
+from observatory.platform.utils.release_utils import get_dataset_releases
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -51,9 +54,6 @@ from observatory.platform.utils.workflow_utils import (
     blob_name,
     make_dag_id,
 )
-from observatory.api.client import ApiClient, Configuration
-from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
-from observatory.platform.utils.release_utils import get_dataset_releases
 
 
 class TestWosUtility(unittest.TestCase):

--- a/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_snapshot_telescope.py
@@ -20,14 +20,16 @@ import re
 from typing import Dict, List, Union
 
 import pendulum
-from airflow.models import Variable
 from airflow.models.taskinstance import TaskInstance
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import (
     AirflowVars,
     get_airflow_connection_url,
 )
 from observatory.platform.utils.file_utils import find_replace_file, gunzip_files
 from observatory.platform.utils.http_download import download_file
+from observatory.platform.utils.release_utils import get_new_release_dates, get_datasets
 from observatory.platform.utils.url_utils import (
     get_http_response_xml_to_dict,
     get_observatory_http_header,
@@ -36,9 +38,6 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
-from observatory.platform.utils.release_utils import get_new_release_dates, get_datasets
-
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 
 
 class UnpaywallSnapshotRelease(SnapshotRelease):
@@ -148,7 +147,6 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         table_descriptions: Dict = None,
         catchup: bool = True,
         airflow_vars: Union[List[AirflowVars], None] = None,
-        org_name: str = "Curtin University",
         workflow_id: int = None,
     ):
         """Initialise the telescope.
@@ -163,7 +161,6 @@ class UnpaywallSnapshotTelescope(SnapshotTelescope):
         :param table_descriptions: Descriptions of the tables.
         :param catchup: Whether Airflow should catch up past dag runs.
         :param airflow_vars: List of Airflow variables to use.
-        :param org_name: Organisation name in the API associated with this Telescope instance.
         :param workflow_id: api workflow id.
         """
 

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -153,7 +153,7 @@ class UnpaywallRelease(StreamRelease):
             target_start_date = pendulum.instance(latest_release.start_date).subtract(days=1).start_of("day")
         # Day after recorded end date
         else:
-            target_start_date = latest_release.end_date.add(seconds=1)
+            target_start_date = pendulum.instance(latest_release.end_date).add(seconds=1)
 
         feeds = UnpaywallRelease.get_unpaywall_daily_feeds()
         filtered_releases = list(

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -14,25 +14,26 @@
 
 # Author: Tuan Chien
 
-import logging
 import os
-from datetime import datetime, timedelta
-from typing import Generator, List, Optional, Tuple, Union
-from airflow.models.taskinstance import TaskInstance
-import requests
+from typing import List
+
 import pendulum
+from airflow.models.taskinstance import TaskInstance
+
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from academic_observatory_workflows.workflows.unpaywall_snapshot_telescope import UnpaywallSnapshotRelease
-from airflow.exceptions import AirflowException
-from airflow.models.dagrun import DagRun
-from croniter import croniter
-from dateutil.relativedelta import relativedelta
 from observatory.platform.utils.airflow_utils import (
     AirflowVars,
     get_airflow_connection_password,
 )
 from observatory.platform.utils.file_utils import find_replace_file, gunzip_files
 from observatory.platform.utils.http_download import download_file
+from observatory.platform.utils.release_utils import (
+    get_dataset_releases,
+    is_first_release,
+    get_datasets,
+    get_latest_dataset_release,
+)
 from observatory.platform.utils.url_utils import (
     get_http_response_json,
     get_observatory_http_header,
@@ -41,12 +42,6 @@ from observatory.platform.utils.url_utils import (
 from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,
-)
-from observatory.platform.utils.release_utils import (
-    get_dataset_releases,
-    is_first_release,
-    get_datasets,
-    get_latest_dataset_release,
 )
 
 
@@ -207,7 +202,6 @@ class UnpaywallTelescope(StreamTelescope):
         merge_partition_field: str = "doi",
         schema_folder: str = default_schema_folder(),
         airflow_vars: List = None,
-        org_name: str = "Curtin University",
         workflow_id: int = None,
     ):
         """Unpaywall Data Feed telescope.
@@ -220,7 +214,6 @@ class UnpaywallTelescope(StreamTelescope):
         :param merge_partition_field: the BigQuery field used to match partitions for a merge
         :param schema_folder: the SQL schema path.
         :param airflow_vars: list of airflow variable keys, for each variable it is checked if it exists in airflow
-        :param org_name: Organisation name in the API associated with this Telescope instance.
         :param workflow_id: API workflow id.
         """
 
@@ -290,7 +283,7 @@ class UnpaywallTelescope(StreamTelescope):
             dataset = get_datasets(workflow_id=self.workflow_id)[0]
             api_releases = get_dataset_releases(dataset_id=dataset.id)
             latest_release = get_latest_dataset_release(api_releases)
-            start_date = latest_release.start_date.isoformat()
+            start_date = latest_release.end_date.isoformat()
             end_date = pendulum.instance(kwargs["data_interval_end"]).start_of("day")
             releases = UnpaywallRelease.get_diff_releases(end_date=end_date, workflow_id=self.workflow_id)
 

--- a/academic_observatory_workflows/workflows/web_of_science_telescope.py
+++ b/academic_observatory_workflows/workflows/web_of_science_telescope.py
@@ -26,9 +26,13 @@ import backoff
 import jsonlines
 import pendulum
 import xmltodict
-from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from airflow.exceptions import AirflowException
 from google.cloud.bigquery import WriteDisposition
+from ratelimit import limits, sleep_and_retry
+from suds import WebFault
+from wos import WosClient
+
+from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import (
     AirflowConns,
     AirflowVars,
@@ -49,9 +53,6 @@ from observatory.platform.workflows.snapshot_telescope import (
     SnapshotRelease,
     SnapshotTelescope,
 )
-from ratelimit import limits, sleep_and_retry
-from suds import WebFault
-from wos import WosClient
 
 
 class WosUtilConst:


### PR DESCRIPTION
Fixes to enable the workflows to function with the API changes:
- Prevent IndexError by only creating workflows where there should be be zero or one workflow instance, when a workflow exists in the database, e.g. Crossref Events, Crossref Fundref etc.
- Scopus: get extras from Workflow rather than DatasetType, because for Scopus, the settings change per workflow (each organisation has a different workflow) rather than globally for the same dataset type.
- Removed / re-sorted imports.