### PR TITLE
Download pre-generated twitter cards

### DIFF
--- a/academic_observatory_workflows/fixtures/oa_web_workflow/test_make_logos.yaml
+++ b/academic_observatory_workflows/fixtures/oa_web_workflow/test_make_logos.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a65ba4502feda214c2d21f7b35ba0cc6c61fe91e11d1c17fc42d961d8722758
-size 21014
+oid sha256:e174db13150d6b9692026755ee8cc022f1c8a3ebea6dbcda7e394893169814d8
+size 62286

--- a/academic_observatory_workflows/workflows/data/oa_web_workflow/twitter.zip
+++ b/academic_observatory_workflows/workflows/data/oa_web_workflow/twitter.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cc5c85affcf4b4ecb5efe5de76dc3eb16fdac4675c6d86aa21b256a59bf094e
+size 6343910

--- a/academic_observatory_workflows/workflows/oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_web_workflow.py
@@ -1385,7 +1385,7 @@ class OaWebWorkflow(Workflow):
         agg_dataset_id: str = "observatory",
         ror_dataset_id: str = "ror",
         settings_dataset_id: str = "settings",
-        version: str = "v3",
+        version: str = "v4",
         conceptrecid: int = 6399462,
         zenodo_host: str = "https://zenodo.org",
     ):

--- a/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
@@ -54,6 +54,7 @@ from academic_observatory_workflows.workflows.oa_web_workflow import (
     publish_new_version,
 )
 from observatory.platform.utils.file_utils import load_jsonl
+from observatory.platform.utils.gc_utils import upload_file_to_cloud_storage
 from observatory.platform.utils.test_utils import (
     ObservatoryEnvironment,
     ObservatoryTestCase,
@@ -1308,6 +1309,12 @@ class TestOaWebWorkflow(ObservatoryTestCase):
                 release_date=execution_date,
             )
 
+            # Upload fake twitter.zip file to bucket
+            file_path = os.path.join(
+                module_file_path("academic_observatory_workflows.workflows.data.oa_web_workflow"), "twitter.zip"
+            )
+            upload_file_to_cloud_storage(data_bucket, "twitter.zip", file_path)
+
             # Run workflow
             workflow = OaWebWorkflow(
                 agg_dataset_id=dataset_id, ror_dataset_id=dataset_id, settings_dataset_id=dataset_id_settings
@@ -1340,6 +1347,10 @@ class TestOaWebWorkflow(ObservatoryTestCase):
 
                 # Make draft Zenodo version
                 ti = env.run_task(workflow.make_draft_zenodo_version.__name__)
+                self.assertEqual(State.SUCCESS, ti.state)
+
+                # Download twitter cards
+                ti = env.run_task(workflow.download_twitter_cards.__name__)
                 self.assertEqual(State.SUCCESS, ti.state)
 
                 # Transform data

--- a/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_oa_web_workflow.py
@@ -896,6 +896,7 @@ class TestOaWebRelease(TestCase):
             df = pd.DataFrame(institutions)
             df = self.release.preprocess_df(category, df)
             df_index_table = self.release.make_index(category, df)
+            sizes = ["l", "s", "xl"]
             with vcr.use_cassette(test_fixtures_folder("oa_web_workflow", "test_make_logos.yaml")):
                 self.release.update_index_with_logos(category, df_index_table)
                 curtin_row = df_index_table.loc["02n415q13"]
@@ -908,7 +909,10 @@ class TestOaWebRelease(TestCase):
 
                     # Check that correct path created
                     item_id = curtin_row["id"]
-                    expected_curtin_path = f"/logos/{category}/{size}/{item_id}.jpg"
+                    fmt = "jpg"
+                    if size == "xl":
+                        fmt = "png"
+                    expected_curtin_path = f"/logos/{category}/{size}/{item_id}.{fmt}"
                     expected_foo_path = f"/unknown.svg"
                     self.assertEqual(expected_curtin_path, curtin_row[key])
                     self.assertEqual(expected_foo_path, foo_row[key])
@@ -1217,7 +1221,8 @@ class TestOaWebWorkflow(ObservatoryTestCase):
                     "check_dependencies": ["query"],
                     "query": ["download"],
                     "download": ["make_draft_zenodo_version"],
-                    "make_draft_zenodo_version": ["transform"],
+                    "make_draft_zenodo_version": ["download_twitter_cards"],
+                    "download_twitter_cards": ["transform"],
                     "transform": ["publish_zenodo_version"],
                     "publish_zenodo_version": ["upload_dataset"],
                     "upload_dataset": ["repository_dispatch"],


### PR DESCRIPTION
This PR downloads pre-generated Twitter cards for all countries and institutions and incorporates them into the final latest.zip file for use by the website.

A few other small changes have been made to support the generation of Twitter cards:
* Added median country and institution statistics to Stats.json.
* Downloaded xl sized png images for each institution.