### PR TITLE
Update OpenAlex

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install --upgrade pip
 
           cd ..
-          git clone -b INF-361_bigquery_snapshot https://github.com/The-Academic-Observatory/observatory-platform.git
+          git clone https://github.com/The-Academic-Observatory/observatory-platform.git
           cd observatory-platform
           pip install -e observatory-api
           pip install -e observatory-platform

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,8 +33,7 @@ jobs:
           python -m pip install --upgrade pip
 
           cd ..
-          git clone https://github.com/The-Academic-Observatory/observatory-platform.git
-          git checkout INF-361_bigquery_snapshot
+          git clone -b INF-361_bigquery_snapshot https://github.com/The-Academic-Observatory/observatory-platform.git
           cd observatory-platform
           pip install -e observatory-api
           pip install -e observatory-platform

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,6 +34,7 @@ jobs:
 
           cd ..
           git clone https://github.com/The-Academic-Observatory/observatory-platform.git
+          git checkout INF-361_bigquery_snapshot
           cd observatory-platform
           pip install -e observatory-api
           pip install -e observatory-platform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         language: script
         stages: [prepare-commit-msg]
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     -   id: black
         args: [--line-length=120]

--- a/academic_observatory_workflows/api_type_ids.py
+++ b/academic_observatory_workflows/api_type_ids.py
@@ -1,0 +1,93 @@
+# Copyright 2020 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Author: Tuan Chien
+
+
+class DatasetTypeId:
+    """DatasetType type_id constants"""
+
+    # academic observatory workflows
+    crossref_events = "crossref_events"
+    crossref_fundref = "crossref_fundref"
+    crossref_metadata = "crossref_metadata"
+    geonames = "geonames"
+    grid = "grid"
+    mag = "mag"
+    open_citations = "open_citations"
+    openalex = "openalex"
+    openalex_author = "openalex_author"
+    openalex_concept = "openalex_concept"
+    openalex_institution = "openalex_institution"
+    openalex_venue = "openalex_venue"
+    openalex_work = "openalex_work"
+    orcid = "orcid"
+    ror = "ror"
+    scopus = "scopus"
+    unpaywall_snapshot = "unpaywall_snapshot"
+    unpaywall = "unpaywall"
+    web_of_science = "web_of_science"
+
+    # oaebu workflows
+    doab = "doab"
+    oapen_metadata = "oapen_metadata"
+    onix = "onix"
+    google_analytics = "google_analytics"
+    google_books_sales = "google_books_sales"
+    google_books_traffic = "google_books_traffic"
+    jstor_country = "jstor_country"
+    jstor_institution = "jstor_institution"
+    oapen_irus_uk = "oapen_irus_uk"
+    ucl_discovery = "ucl_discovery"
+
+    # Workflow dataset types, i.e., dataset types for datasets created by various non Telescope workflows.
+    doi_workflow = "doi"
+    onix_workflow = "onix_workflow"
+    oapen_workflow = "oapen_workflow"
+
+
+class WorkflowTypeId:
+    """WorkflowTypeId type_id constants"""
+
+    # academic observatory workflows
+    crossref_events = "crossref_events"
+    crossref_fundref = "crossref_fundref"
+    crossref_metadata = "crossref_metadata"
+    geonames = "geonames"
+    grid = "grid"
+    mag = "mag"
+    open_citations = "open_citations"
+    openalex = "openalex"
+    orcid = "orcid"
+    ror = "ror"
+    scopus = "scopus"
+    unpaywall_snapshot = "unpaywall_snapshot"
+    unpaywall = "unpaywall"
+    web_of_science = "web_of_science"
+
+    # oaebu workflows
+    doab = "doab"
+    oapen_metadata = "oapen_metadata"
+    onix = "onix"
+    google_analytics = "google_analytics"
+    google_books = "google_books"
+    jstor = "jstor"
+    oapen_irus_uk = "oapen_irus_uk"
+    ucl_discovery = "ucl_discovery"
+
+    # Workflow dataset types, i.e., dataset types for datasets created by various non Telescope workflows.
+    doi_workflow = "doi"
+    onix_workflow = "onix_workflow"
+    oapen_workflow = "oapen_workflow"

--- a/academic_observatory_workflows/api_type_ids.py
+++ b/academic_observatory_workflows/api_type_ids.py
@@ -40,22 +40,8 @@ class DatasetTypeId:
     unpaywall = "unpaywall"
     web_of_science = "web_of_science"
 
-    # oaebu workflows
-    doab = "doab"
-    oapen_metadata = "oapen_metadata"
-    onix = "onix"
-    google_analytics = "google_analytics"
-    google_books_sales = "google_books_sales"
-    google_books_traffic = "google_books_traffic"
-    jstor_country = "jstor_country"
-    jstor_institution = "jstor_institution"
-    oapen_irus_uk = "oapen_irus_uk"
-    ucl_discovery = "ucl_discovery"
-
     # Workflow dataset types, i.e., dataset types for datasets created by various non Telescope workflows.
     doi_workflow = "doi"
-    onix_workflow = "onix_workflow"
-    oapen_workflow = "oapen_workflow"
 
 
 class WorkflowTypeId:
@@ -77,17 +63,5 @@ class WorkflowTypeId:
     unpaywall = "unpaywall"
     web_of_science = "web_of_science"
 
-    # oaebu workflows
-    doab = "doab"
-    oapen_metadata = "oapen_metadata"
-    onix = "onix"
-    google_analytics = "google_analytics"
-    google_books = "google_books"
-    jstor = "jstor"
-    oapen_irus_uk = "oapen_irus_uk"
-    ucl_discovery = "ucl_discovery"
-
     # Workflow dataset types, i.e., dataset types for datasets created by various non Telescope workflows.
     doi_workflow = "doi"
-    onix_workflow = "onix_workflow"
-    oapen_workflow = "oapen_workflow"

--- a/academic_observatory_workflows/database/schema/openalex/Author_2022-06-02.json
+++ b/academic_observatory_workflows/database/schema/openalex/Author_2022-06-02.json
@@ -1,0 +1,173 @@
+[
+  {
+    "name": "id",
+    "type": "STRING",
+    "description": "The OpenAlex ID for this author."
+  },
+  {
+    "name": "orcid",
+    "type": "STRING",
+    "description": "The ORCID for this author. ORCID global and unique ID for authors."
+  },
+  {
+    "name": "display_name",
+    "type": "STRING",
+    "description": "The name of the author as a single string."
+  },
+  {
+    "name": "display_name_alternatives",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "Other ways that we've found this author's name displayed."
+  },
+  {
+    "name": "works_count",
+    "type": "INTEGER",
+    "description": "The number of Works this this author has created."
+  },
+  {
+    "name": "cited_by_count",
+    "type": "INTEGER",
+    "description": "The total number Works that cite a work this author has created."
+  },
+  {
+    "name": "ids",
+    "type": "RECORD",
+    "description": "All the persistent identifiers (PIDs) that we know about for this author, as key: value pairs, where key is the PID namespace, and value is the PID. IDs are expressed as URIs where possible. The openalex ID is the same one you'll find at Author.id. All the IDs are strings except for mag, which is an integer.",
+    "fields": [
+      {
+        "name": "openalex",
+        "type": "STRING",
+        "description": "this author's OpenAlex ID. Same as Author.id"
+      },
+      {
+        "name": "orcid",
+        "type": "STRING",
+        "description": "this author's ORCID ID. Same as Author.orcid"
+      },
+      {
+        "name": "scopus",
+        "type": "STRING",
+        "description": "this author's Scopus author ID"
+      },
+      {
+        "name": "twitter",
+        "type": "STRING",
+        "description": "this author's Twitter handle"
+      },
+      {
+        "name": "wikipedia",
+        "type": "STRING",
+        "description": "this author's Wikipedia page"
+      },
+      {
+        "name": "mag",
+        "type": "INTEGER",
+        "description": "this author's Microsoft Academic Graph ID"
+      }
+    ]
+  },
+  {
+    "name": "last_known_institution",
+    "type": "RECORD",
+    "description": "This author's last known institutional affiliation. In this context \"last known\" means that we took all the Works where this author has an institutional affiliation, sorted them by publication date, and selected the most recent one. This is a dehydrated Institution object, and you can find more documentation on the Institution page.",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this institution."
+      },
+      {
+        "name": "ror",
+        "type": "STRING",
+        "description": "The ROR ID for this institution. The ROR (Research Organization Registry) identifier is a globally unique ID for research organization. ROR is the successor to GRiD, which is no longer being updated."
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The primary name of the institution."
+      },
+      {
+        "name": "country_code",
+        "type": "STRING",
+        "description": "The country where this institution is located, represented as an ISO two-letter country code."
+      },
+      {
+        "name": "type",
+        "type": "STRING",
+        "description": "The institution's primary type, using the ROR \"type\" controlled vocabulary. Possible values are: Education, Healthcare, Company, Archive, Nonprofit, Government, Facility, and Other."
+      }
+    ]
+  },
+  {
+    "name": "x_concepts",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "The \"x\" in x_concepts is because it's experimental and subject to removal with very little warning. We plan to replace it with a custom link to the Concepts API endpoint.",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this concept."
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "The Wikidata ID for this concept. "
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The English-language label of the concept."
+      },
+      {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "The level in the concept tree where this concept lives."
+      },
+      {
+        "name": "score",
+        "type": "FLOAT",
+        "description": "The strength of association between this author and the listed concept, from 0-100."
+      }
+    ]
+  },
+  {
+    "name": "counts_by_year",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "Author.works_count and Author.cited_by_count for each of the last ten years, binned by year. To put it another way: each year, you can see how many works this author published, and how many times they got cited. Any works or citations older than ten years old aren't included.",
+    "fields": [
+      {
+        "name": "year",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "name": "works_count",
+        "type": "INTEGER",
+        "description": "The number of  Works this this author has created."
+      },
+      {
+        "name": "cited_by_count",
+        "type": "INTEGER",
+        "description": "The total number  Works that cite a work this author has created."
+      }
+    ]
+  },
+  {
+    "name": "works_api_url",
+    "type": "STRING",
+    "description": " A URL that will get you a list of all this author's works. We express this as an API URL (instead of just listing the works themselves) because sometimes an author's publication list is too long to reasonably fit into a single author object."
+  },
+  {
+    "name": "updated_date",
+    "type": "STRING",
+    "description": "The last time anything in this author object changed, expressed as an ISO 8601 date string. This date is updated for any change at all, including increases in various counts."
+  },
+  {
+    "name": "created_date",
+    "type": "STRING",
+    "description": "The date this Author object was created in the OpenAlex dataset, expressed as an ISO 8601 date string."
+  }
+]

--- a/academic_observatory_workflows/database/schema/openalex/Concept_2022-06-02.json
+++ b/academic_observatory_workflows/database/schema/openalex/Concept_2022-06-02.json
@@ -1,0 +1,230 @@
+[
+  {
+    "name": "id",
+    "type": "STRING",
+    "description": "The OpenAlex ID for this concept."
+  },
+  {
+    "name": "wikidata",
+    "type": "STRING",
+    "description": "The Wikidata ID for this concept. This is the Canonical External ID for concepts."
+  },
+  {
+    "name": "display_name",
+    "type": "STRING",
+    "description": "The English-language label of the concept."
+  },
+  {
+    "name": "level",
+    "type": "INTEGER",
+    "description": "The level in the concept tree where this concept lives."
+  },
+  {
+    "name": "description",
+    "type": "STRING",
+    "description": "A brief description of this concept."
+  },
+  {
+    "name": "works_count",
+    "type": "INTEGER",
+    "description": "The number of works tagged with this concept."
+  },
+  {
+    "name": "cited_by_count",
+    "type": "INTEGER",
+    "description": "The number citations to works that have been tagged with this concept. Or less formally: the number of citations to this concept. For example, if there are just two works tagged with this concept and one of them has been cited 10 times, and the other has been cited 1 time, cited_by_count for this concept would be 11."
+  },
+  {
+    "name": "ids",
+    "type": "RECORD",
+    "description": "All the persistent identifiers (PIDs) that we know about for this venue, as key: value pairs, where key is the PID namespace, and value is the PID. IDs are expressed as URIs where possible. umls_aui and umls_cui refer to the Unified Medical Language System Atom Unique Identifier and Concept Unique Identifier respectively. These are lists. The other IDs are all strings, except except for mag, which is a long integer.",
+    "fields": [
+      {
+        "name": "openalex",
+        "type": "STRING",
+        "description": "this concept's OpenAlex ID. Same as Concept.id"
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "this concept's Wikidata ID. Same as Concept.wikidata"
+      },
+      {
+        "name": "wikipedia",
+        "type": "STRING",
+        "description": "this concept's Wikipedia page URL"
+      },
+      {
+        "name": "umls_aui",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "this concept's Unified Medical Language System Atom Unique Identifiers"
+      },
+      {
+        "name": "umls_cui",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "this concept's Unified Medical Language System Concept Unique Identifiers"
+      },
+      {
+        "name": "mag",
+        "type": "INTEGER",
+        "description": "this concept's Microsoft Academic Graph ID"
+      }
+    ]
+  },
+  {
+    "name": "image_url",
+    "type": "STRING",
+    "description": "URL where you can get an image representing this concept, where available. Usually this is hosted on Wikipedia."
+  },
+  {
+    "name": "image_thumbnail_url",
+    "type": "STRING",
+    "description": "Same as image_url, but it's a smaller image."
+  },
+  {
+    "name": "international",
+    "type": "RECORD",
+    "description": "todo",
+    "fields": [
+      {
+        "name": "display_name",
+        "type": "RECORD",
+        "description": "",
+        "fields": [
+          {
+            "name": "keys",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI. Originally each language was a key and the display name in that language the corresponding value."
+          },
+          {
+            "name": "values",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI. Originally each language was a key and the display name in that language the corresponding value."
+          }
+        ]
+      },
+      {
+        "name": "description",
+        "type": "RECORD",
+        "description": "",
+        "fields": [
+          {
+            "name": "keys",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI."
+          },
+          {
+            "name": "values",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "ancestors",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "List of concepts that this concept descends from, as dehydrated Concept objects. See the concept tree section for more details on how the different layers of concepts work together.",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this concept."
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "The Wikidata ID for this concept. "
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The English-language label of the concept."
+      },
+      {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "The level in the concept tree where this concept lives."
+      }
+    ]
+  },
+  {
+    "name": "related_concepts",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "Concepts that are similar to this one. Each listed concept is a dehydrated Concept object, with one additional attribute",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this concept."
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "The Wikidata ID for this concept. "
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The English-language label of the concept."
+      },
+      {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "The level in the concept tree where this concept lives."
+      },
+      {
+        "name": "score",
+        "type": "FLOAT",
+        "description": "The strength of association between this concept and the listed concept, on a scale of 0-100."
+      }
+    ]
+  },
+  {
+    "name": "counts_by_year",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "The values of works_count and cited_by_count for each of the last ten years, binned by year. To put it another way: for every listed year, you can see how many new works were tagged with this concept, and how many times any work tagged with this concept got cited.",
+    "fields": [
+      {
+        "name": "year",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "name": "works_count",
+        "type": "INTEGER",
+        "description": "The number of works tagged with this concept."
+      },
+      {
+        "name": "cited_by_count",
+        "type": "INTEGER",
+        "description": "The number citations to works that have been tagged with this concept. Or less formally: the number of citations to this concept. For example, if there are just two works tagged with this concept and one of them has been cited 10 times, and the other has been cited 1 time, cited_by_count for this concept would be 11."
+      }
+    ]
+  },
+  {
+    "name": "works_api_url",
+    "type": "STRING",
+    "description": "An URL that will get you a list of all the works tagged with this concept. We express this as an API URL (instead of just listing the works themselves) because there might be millions of works tagged with this concept, and that's too many to fit here."
+  },
+  {
+    "name": "updated_date",
+    "type": "STRING",
+    "description": "The last time anything in this concept object changed, expressed as an ISO 8601 date string. This date is updated for any change at all, including increases in various counts."
+  },
+  {
+    "name": "created_date",
+    "type": "STRING",
+    "description": "The date this Concept object was created in the OpenAlex dataset, expressed as an ISO 8601 date string."
+  }
+]

--- a/academic_observatory_workflows/database/schema/openalex/Institution_2022-06-02.json
+++ b/academic_observatory_workflows/database/schema/openalex/Institution_2022-06-02.json
@@ -1,0 +1,297 @@
+[
+  {
+    "name": "id",
+    "type": "STRING",
+    "description": "The OpenAlex ID for this institution."
+  },
+  {
+    "name": "ror",
+    "type": "STRING",
+    "description": "The ROR ID for this institution. The ROR (Research Organization Registry) identifier is a globally unique ID for research organization. ROR is the successor to GRiD, which is no longer being updated."
+  },
+  {
+    "name": "display_name",
+    "type": "STRING",
+    "description": "The primary name of the institution."
+  },
+  {
+    "name": "country_code",
+    "type": "STRING",
+    "description": "The country where this institution is located, represented as an ISO two-letter country code."
+  },
+  {
+    "name": "type",
+    "type": "STRING",
+    "description": "The institution's primary type, using the ROR \"type\" controlled vocabulary. Possible values are: Education, Healthcare, Company, Archive, Nonprofit, Government, Facility, and Other."
+  },
+  {
+    "name": "homepage_url",
+    "type": "STRING",
+    "description": "The URL for institution's primary homepage"
+  },
+  {
+    "name": "image_url",
+    "type": "STRING",
+    "description": "URL where you can get an image representing this institution. Usually this is hosted on Wikipedia, and usually it's a seal or logo."
+  },
+  {
+    "name": "image_thumbnail_url",
+    "type": "STRING",
+    "description": "Same as image_url, but it's a smaller image."
+  },
+  {
+    "name": "display_name_acronyms",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "Acronyms or initialisms that people sometimes use instead of the full display_name."
+  },
+  {
+    "name": "display_name_alternatives",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "Other names people may use for this institution.  "
+  },
+  {
+    "name": "works_count",
+    "type": "INTEGER",
+    "description": "The number of Works created by authors affiliated with this institution. Or less formally: the number of works coming out of this institution."
+  },
+  {
+    "name": "cited_by_count",
+    "type": "INTEGER",
+    "description": "The total number Works that cite a work created by an author affiliated with this institution. Or less formally: the number of citations this institution has collected."
+  },
+  {
+    "name": "ids",
+    "type": "RECORD",
+    "description": "All the persistent identifiers (PIDs) that we know about for this institution, as key: value pairs, where key is the PID namespace, and value is the PID. IDs are expressed as URIs where possible. They're all strings except for mag, which is a long integer.",
+    "fields": [
+      {
+        "name": "openalex",
+        "type": "STRING",
+        "description": "this institution's OpenAlex ID. Same as Institution.id"
+      },
+      {
+        "name": "ror",
+        "type": "STRING",
+        "description": "this institution's ROR ID. Same as Institution.ror"
+      },
+      {
+        "name": "grid",
+        "type": "STRING",
+        "description": "this institution's GRID ID"
+      },
+      {
+        "name": "wikipedia",
+        "type": "STRING",
+        "description": "this institution's Wikipedia page URL"
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "this institution's Wikidata ID"
+      },
+      {
+        "name": "mag",
+        "type": "INTEGER",
+        "description": "this institution's Microsoft Academic Graph ID"
+      }
+    ]
+  },
+  {
+    "name": "geo",
+    "type": "RECORD",
+    "description": "A bunch of stuff we know about the location of this institution:",
+    "fields": [
+      {
+        "name": "city",
+        "type": "STRING",
+        "description": "The city where this institution lives."
+      },
+      {
+        "name": "geonames_city_id",
+        "type": "STRING",
+        "description": "The city where this institution lives, as a GeoNames database ID."
+      },
+      {
+        "name": "region",
+        "type": "STRING",
+        "description": "The sub-national region (state, province) where this institution lives."
+      },
+      {
+        "name": "country_code",
+        "type": "STRING",
+        "description": "The country where this institution lives, represented as an ISO two-letter country code."
+      },
+      {
+        "name": "country",
+        "type": "STRING",
+        "description": "The country where this institution lives."
+      },
+      {
+        "name": "latitude",
+        "type": "FLOAT",
+        "description": "Does what it says."
+      },
+      {
+        "name": "longitude",
+        "type": "FLOAT",
+        "description": "Does what it says."
+      }
+    ]
+  },
+  {
+    "name": "international",
+    "type": "RECORD",
+    "description": "todo",
+    "fields": [
+      {
+        "name": "display_name",
+        "type": "RECORD",
+        "description": "",
+        "fields": [
+          {
+            "name": "keys",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI. Originally each language was a key and the display name in that language the corresponding value."
+          },
+          {
+            "name": "values",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI. Originally each language was a key and the display name in that language the corresponding value."
+          }
+        ]
+      },
+      {
+        "name": "description",
+        "type": "RECORD",
+        "description": "",
+        "fields": [
+          {
+            "name": "keys",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI."
+          },
+          {
+            "name": "values",
+            "type": "STRING",
+            "mode": "REPEATED",
+            "description": "Custom field created by COKI."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "associated_institutions",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this institution."
+      },
+      {
+        "name": "ror",
+        "type": "STRING",
+        "description": "The ROR ID for this institution. The ROR (Research Organization Registry) identifier is a globally unique ID for research organization. ROR is the successor to GRiD, which is no longer being updated."
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The primary name of the institution."
+      },
+      {
+        "name": "country_code",
+        "type": "STRING",
+        "description": "The country where this institution is located, represented as an ISO two-letter country code."
+      },
+      {
+        "name": "type",
+        "type": "STRING",
+        "description": "The institution's primary type, using the ROR \"type\" controlled vocabulary. Possible values are: Education, Healthcare, Company, Archive, Nonprofit, Government, Facility, and Other."
+      },
+      {
+        "name": "relationship",
+        "type": "STRING",
+        "description": "The type of relationship between this institution and the listed institution. Possible values: parent, child, and related."
+      }
+    ]
+  },
+  {
+    "name": "counts_by_year",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "works_count and cited_by_count for each of the last ten years, binned by year. To put it another way: each year, you can see how many new works this venue started hosting, and how many times any work in this venue got cited.",
+    "fields": [
+      {
+        "name": "year",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "name": "works_count",
+        "type": "INTEGER",
+        "description": "The number of Works created by authors affiliated with this institution. Or less formally: the number of works coming out of this institution."
+      },
+      {
+        "name": "cited_by_count",
+        "type": "INTEGER",
+        "description": "The total number Works that cite a work created by an author affiliated with this institution. Or less formally: the number of citations this institution has collected."
+      }
+    ]
+  },
+  {
+    "name": "x_concepts",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "The \"x\" in x_concepts is because it's experimental and subject to removal with very little warning. We plan to replace it with a custom link to the Concepts API endpoint. The Concepts most frequently applied to works affiliated with this institution. Each is represented as a dehydrated Concept object, with one additional attribute",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this concept."
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "The Wikidata ID for this concept. "
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The English-language label of the concept."
+      },
+      {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "The level in the concept tree where this concept lives."
+      },
+      {
+        "name": "score",
+        "type": "FLOAT",
+        "description": "The strength of association between this institution and the listed concept, from 0-100."
+      }
+    ]
+  },
+  {
+    "name": "works_api_url",
+    "type": "STRING",
+    "description": " A URL that will get you a list of all the Works affiliated with this institution. We express this as an API URL (instead of just listing the Works themselves) because most institutions have way too many works to reasonably fit into a single return object."
+  },
+  {
+    "name": "updated_date",
+    "type": "STRING",
+    "description": "The last time anything in this Institution changed, expressed as an ISO 8601 date string. This date is updated for any change at all, including increases in various counts."
+  },
+  {
+    "name": "created_date",
+    "type": "STRING",
+    "description": "The date this Institution object was created in the OpenAlex dataset, expressed as an ISO 8601 date string."
+  }
+]

--- a/academic_observatory_workflows/database/schema/openalex/Venue_2022-06-02.json
+++ b/academic_observatory_workflows/database/schema/openalex/Venue_2022-06-02.json
@@ -1,0 +1,152 @@
+[
+  {
+    "name": "id",
+    "type": "STRING",
+    "description": "The OpenAlex ID for this venue."
+  },
+  {
+    "name": "issn_l",
+    "type": "STRING",
+    "description": "The ISSN-L identifying this venue. ISSN is a global and unique ID for serial publications. However, different media versions of a given publication (e.g., print and electronic) often have different ISSNs. This is why we can't have nice things. The ISSN-L or Linking ISSN solves the problem by designating a single canonical ISSN for all media versions of the title. It's usually the same as the print ISSN."
+  },
+  {
+    "name": "issn",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "The ISSNs used by this venue. Many publications have multiple ISSNs (see above), so ISSN-L should be used when possible."
+  },
+  {
+    "name": "display_name",
+    "type": "STRING",
+    "description": "The name of the venue."
+  },
+  {
+    "name": "publisher",
+    "type": "STRING",
+    "description": "The name of this venue's publisher. Publisher is a tricky category, as journals often change publishers, publishers merge, publishers have subsidiaries (\"imprints\"), and of course no one is consistent in their naming. In the future, we plan to roll out support for a more structured publisher field, but for now it's just a string."
+  },
+  {
+    "name": "works_count",
+    "type": "INTEGER",
+    "description": "The number of Works this this venue hosts."
+  },
+  {
+    "name": "cited_by_count",
+    "type": "INTEGER",
+    "description": "The total number of Works that cite a Work hosted in this venue."
+  },
+  {
+    "name": "is_oa",
+    "type": "BOOLEAN",
+    "description": "todo"
+  },
+  {
+    "name": "is_in_doaj",
+    "type": "BOOLEAN",
+    "description": "todo"
+  },
+  {
+    "name": "homepage_url",
+    "type": "STRING",
+    "description": "todo"
+  },
+  {
+    "name": "ids",
+    "type": "RECORD",
+    "description": "All the persistent identifiers (PIDs) that we know about for this venue, as key: value pairs, where key is the PID namespace, and value is the PID. IDs are expressed as URIs where possible.",
+    "fields": [
+      {
+        "name": "openalex",
+        "type": "STRING",
+        "description": "this venue's OpenAlex ID. Same as Venue.id"
+      },
+      {
+        "name": "issn_l",
+        "type": "STRING",
+        "description": "this venue's ISSN-L. Same as Venue.issn_l"
+      },
+      {
+        "name": "issn",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "a list of this venue's ISSNs. Same as Venue.issn"
+      },
+      {
+        "name": "mag",
+        "type": "INTEGER",
+        "description": "this venue's Microsoft Academic Graph ID"
+      }
+    ]
+  },
+  {
+    "name": "x_concepts",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "The \"x\" in x_concepts is because it's experimental and subject to removal with very little warning. We plan to replace it with a custom link to the Concepts API endpoint. The Concepts most frequently applied to works hosted by this venue. Each is represented as a dehydrated Concept object, with one additional attribute:",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this concept."
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "The Wikidata ID for this concept."
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The English-language label of the concept."
+      },
+      {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "The level in the concept tree where this concept lives."
+      },
+      {
+        "name": "score",
+        "type": "FLOAT",
+        "description": "The strength of association between this venue and the listed concept, from 0-100."
+      }
+    ]
+  },
+  {
+    "name": "counts_by_year",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "works_count and cited_by_count for each of the last ten years, binned by year. To put it another way: each year, you can see how many new works this venue started hosting, and how many times any work in this venue got cited.\nIf the venue was founded less than ten years ago, there will naturally be fewer than ten years in this list.",
+    "fields": [
+      {
+        "name": "year",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "name": "works_count",
+        "type": "INTEGER",
+        "description": "The number of Works this this venue hosts."
+      },
+      {
+        "name": "cited_by_count",
+        "type": "INTEGER",
+        "description": "The total number of Works that cite a Work hosted in this venue."
+      }
+    ]
+  },
+  {
+    "name": "works_api_url",
+    "type": "STRING",
+    "description": "A URL that will get you a list of all this venue's Works.\nWe express this as an API URL (instead of just listing the works themselves) because sometimes a venue's publication list is too long to reasonably fit into a single Venue object."
+  },
+  {
+    "name": "updated_date",
+    "type": "STRING",
+    "description": "The last time anything in this Venue object changed, expressed as an ISO 8601 date string. This date is updated for any change at all, including increases in various counts."
+  },
+  {
+    "name": "created_date",
+    "type": "STRING",
+    "description": "The date this Venue object was created in the OpenAlex dataset, expressed as an ISO 8601 date string."
+  }
+]

--- a/academic_observatory_workflows/database/schema/openalex/Work_2022-06-02.json
+++ b/academic_observatory_workflows/database/schema/openalex/Work_2022-06-02.json
@@ -1,0 +1,458 @@
+[
+  {
+    "name": "id",
+    "type": "STRING",
+    "description": "The OpenAlex ID for this work."
+  },
+  {
+    "name": "doi",
+    "type": "STRING",
+    "description": "The DOI for the work. Occasionally, a work has more than one DOI--for example, there might be one DOI for a preprint version hosted on bioRxiv, and another DOI for the published version. However, this field always has just one DOI, the DOI for the published work. If you want DOIs for other versions, you can find them in the Work.alternate_host_venues list."
+  },
+  {
+    "name": "title",
+    "type": "STRING",
+    "description": "The title of this work."
+  },
+  {
+    "name": "display_name",
+    "type": "STRING",
+    "description": "Exactly the same as Work.title. It's useful for Works to include a display_name property, since all the other entities have one."
+  },
+  {
+    "name": "publication_year",
+    "type": "INTEGER",
+    "description": "The year this work was published."
+  },
+  {
+    "name": "publication_date",
+    "type": "STRING",
+    "description": "The day when this work was published, formatted as an ISO 8601 date.\nWhere different publication dates exist, we select the earliest available date of electronic publication. \nThis date applies to the version found at Work.url. The other versions, found in Work.alternate_host_venues, may have been published at different (earlier) dates."
+  },
+  {
+    "name": "ids",
+    "type": "RECORD",
+    "description": "All the persistent identifiers (PIDs) that we know about for this work, as key: value pairs, where key is the PID namespace, and value is the PID. IDs are expressed as URIs where possible.",
+    "fields": [
+      {
+        "name": "openalex",
+        "type": "STRING",
+        "description": "The OpenAlex ID. Same as Work.id"
+      },
+      {
+        "name": "doi",
+        "type": "STRING",
+        "description": "The DOI. Same as Work.doi"
+      },
+      {
+        "name": "mag",
+        "type": "INTEGER",
+        "description": "The Microsoft Academic Graph ID"
+      },
+      {
+        "name": "pmid",
+        "type": "STRING",
+        "description": "The Pubmed Identifier"
+      },
+      {
+        "name": "pmcid",
+        "type": "STRING",
+        "description": "the Pubmed Central identifier"
+      }
+    ]
+  },
+  {
+    "name": "host_venue",
+    "type": "RECORD",
+    "description": "A HostVenue object describing how and where this work is being hosted online.",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this venue."
+      },
+      {
+        "name": "issn_l",
+        "type": "STRING",
+        "description": "The ISSN-L identifying this venue. ISSN is a global and unique ID for serial publications. However, different media versions of a given publication (e.g., print and electronic) often have different ISSNs. This is why we can't have nice things. The ISSN-L or Linking ISSN solves the problem by designating a single canonical ISSN for all media versions of the title. It's usually the same as the print ISSN."
+      },
+      {
+        "name": "issn",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "The ISSNs used by this venue. Many publications have multiple ISSNs (see above), so ISSN-L should be used when possible."
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The name of the venue."
+      },
+      {
+        "name": "publisher",
+        "type": "STRING",
+        "description": "The name of this venue's publisher. Publisher is a tricky category, as journals often change publishers, publishers merge, publishers have subsidiaries (\"imprints\"), and of course no one is consistent in their naming. In the future, we plan to roll out support for a more structured publisher field, but for now it's just a string."
+      },
+      {
+        "name": "type",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "url",
+        "type": "STRING",
+        "description": "The URL where you can access this work."
+      },
+      {
+        "name": "is_oa",
+        "type": "BOOLEAN",
+        "description": "Set to true if the work hosted here can be read for free, without registration."
+      },
+      {
+        "name": "version",
+        "type": "STRING",
+        "description": "The version of the work, based on the DRIVER Guidelines versioning scheme. Possible values are: -publishedVersion: The document’s version of record. This is the most authoritative version. -acceptedVersion: The document after having completed peer review and being officially accepted for publication. It will lack publisher formatting, but the content should be interchangeable with the that of the publishedVersion. -submittedVersion: the document as submitted to the publisher by the authors, but before peer-review. Its content may differ significantly from that of the accepted article."
+      },
+      {
+        "name": "license",
+        "type": "STRING",
+        "description": "The license applied to this work at this host. Most toll-access works don't have an explicit license (they're under \"all rights reserved\" copyright), so this field generally has content only if is_oa is true."
+      }
+    ]
+  },
+  {
+    "name": "type",
+    "type": "STRING",
+    "description": "The type or genre of the work. This field uses Crossref's \"type\" controlled vocabulary; you can see all possible values via the Crossref api here: https://api.crossref.org/types. Where possible, we just pass along Crossref's type value for each work. When that's impossible (eg the work isn't in Crossref), we do our best to figure out the type ourselves. Unfortunately the accuracy of Crossref's data for this isn't great, and ours isn't much better. We're working to develop better type classification."
+  },
+  {
+    "name": "open_access",
+    "type": "RECORD",
+    "description": "Information about the access status of this work, as an OpenAccess object.",
+    "fields": [
+      {
+        "name": "is_oa",
+        "type": "BOOLEAN",
+        "description": "True if this work is Open Access (OA). There are many ways to define OA. OpenAlex uses a broad definition: having a URL where you can read the fulltext of this work without needing to pay money or log in. You can use the alternate_host_venues and oa_status fields to narrow your results further, accommodating any definition of OA you like."
+      },
+      {
+        "name": "oa_status",
+        "type": "STRING",
+        "description": "The Open Access (OA) status of this work. Possible values are: -gold: Published in an OA journal that is indexed by the DOAJ. -green: Toll-access on the publisher landing page, but there is a free copy in an OA repository. -hybrid: Free under an open license in a toll-access journal. -bronze: Free to read on the publisher landing page, but without any identifiable license. -closed: All other articles."
+      },
+      {
+        "name": "oa_url",
+        "type": "STRING",
+        "description": "The best Open Access (OA) URL for this work. Although there are many ways to define OA, in this context an OA URL is one where you can read the fulltext of this work without needing to pay money or log in. The \"best\" such URL is the one closest to the version of record. This URL might be a direct link to a PDF, or it might be to a landing page that links to the free PDF"
+      }
+    ]
+  },
+  {
+    "name": "authorships",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "List of Authorship objects, each representing an author and their institution.",
+    "fields": [
+      {
+        "name": "author_position",
+        "type": "STRING",
+        "description": "A summarized description of this author's position in the work's author list. Possible values are first, middle, and last. It's not strictly necessary, because author order is already implicitly recorded by the list order of Authorship objects; however it's useful in some contexts to have this as a categorical value."
+      },
+      {
+        "name": "author",
+        "type": "RECORD",
+        "description": "An author of this work, as a dehydrated Author object.",
+        "fields": [
+          {
+            "name": "id",
+            "type": "STRING",
+            "description": "The OpenAlex ID for this author."
+          },
+          {
+            "name": "display_name",
+            "type": "STRING",
+            "description": "The name of the author as a single string."
+          },
+          {
+            "name": "orcid",
+            "type": "STRING",
+            "description": "The ORCID for this author. ORCID global and unique ID for authors."
+          }
+        ]
+      },
+      {
+        "name": "institutions",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "description": "The institutional affiliations this author claimed in the context of this work, as dehydrated Institution objects.",
+        "fields": [
+          {
+            "name": "id",
+            "type": "STRING",
+            "description": "The OpenAlex ID for this institution."
+          },
+          {
+            "name": "ror",
+            "type": "STRING",
+            "description": "The ROR ID for this institution. The ROR (Research Organization Registry) identifier is a globally unique ID for research organization. ROR is the successor to GRiD, which is no longer being updated."
+          },
+          {
+            "name": "display_name",
+            "type": "STRING",
+            "description": "The primary name of the institution."
+          },
+          {
+            "name": "country_code",
+            "type": "STRING",
+            "description": "The country where this institution is located, represented as an ISO two-letter country code."
+          },
+          {
+            "name": "type",
+            "type": "STRING",
+            "description": "The institution's primary type, using the ROR \"type\" controlled vocabulary. Possible values are: Education, Healthcare, Company, Archive, Nonprofit, Government, Facility, and Other."
+          }
+        ]
+      },
+      {
+        "name": "raw_affiliation_string",
+        "type": "STRING",
+        "description": "This author's affiliation as it originally came to us (on a webpage or in an API), as a raw unformatted string. "
+      }
+    ]
+  },
+  {
+    "name": "cited_by_count",
+    "type": "INTEGER",
+    "description": "The number of citations to this work. These are the times that other works have cited this work: Other works ➞ This work."
+  },
+  {
+    "name": "biblio",
+    "type": "RECORD",
+    "description": "Old-timey bibliographic info for this work. This is mostly useful only in citation/reference contexts. These are all strings because sometimes you'll get fun values like \"Spring\" and \"Inside cover.\"",
+    "fields": [
+      {
+        "name": "volume",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "issue",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "first_page",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "last_page",
+        "type": "STRING",
+        "description": ""
+      }
+    ]
+  },
+  {
+    "name": "is_retracted",
+    "type": "BOOLEAN",
+    "description": "True if we know this work has been retracted. This field has high precision but low recall. In other words, if is_retracted is  true, the article is definitely retracted. But if is_retracted is False,  it still might be retracted, but we just don't know. This is because unfortunately, the open sources for retraction data aren't currently very comprehensive, and the more comprehensive ones aren't sufficiently open for us to use here."
+  },
+  {
+    "name": "is_paratext",
+    "type": "BOOLEAN",
+    "description": "True if we think this work is paratext. In our context, paratext is stuff that's in scholarly venue (like a journal) but is about the venue rather than a scholarly work properly speaking.  Some examples and nonexamples: -yep it's paratext: front cover, back cover, table of contents, editorial board listing, issue information,  masthead. -no,  not paratext: research paper, dataset, letters to the editor, figures. Turns out there is a lot of paratext in registries like Crossref. That's not a bad thing... but we've found that it's good to have a way to filter it out.\nWe determine is_paratext algorithmically using title heuristics. "
+  },
+  {
+    "name": "concepts",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "List of dehydrated Concept objects. \nEach Concept object in the list also has one additional property",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this concept."
+      },
+      {
+        "name": "wikidata",
+        "type": "STRING",
+        "description": "The Wikidata ID for this concept. "
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The English-language label of the concept."
+      },
+      {
+        "name": "level",
+        "type": "INTEGER",
+        "description": "The level in the concept tree where this concept lives."
+      },
+      {
+        "name": "score",
+        "type": "FLOAT",
+        "description": "The strength of the connection between the work and this concept (higher is stronger)."
+      }
+    ]
+  },
+  {
+    "name": "mesh",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "List of MeSH tag objects. Only works found in PubMed have MeSH tags; for all other works, this is an empty list.",
+    "fields": [
+      {
+        "name": "descriptor_ui",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "descriptor_name",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "qualifier_ui",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "qualifier_name",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "is_major_topic",
+        "type": "BOOLEAN",
+        "description": ""
+      }
+    ]
+  },
+  {
+    "name": "alternate_host_venues",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "List of HostVenue objects describing places this work lives. This work's primary hosting venue isn't in this list; it's at host_venue. Some venues in this list are missing the id field! This should be fixed by February 2022.",
+    "fields": [
+      {
+        "name": "id",
+        "type": "STRING",
+        "description": "The OpenAlex ID for this venue."
+      },
+      {
+        "name": "issn_l",
+        "type": "STRING",
+        "description": "The ISSN-L identifying this venue. ISSN is a global and unique ID for serial publications. However, different media versions of a given publication (e.g., print and electronic) often have different ISSNs. This is why we can't have nice things. The ISSN-L or Linking ISSN solves the problem by designating a single canonical ISSN for all media versions of the title. It's usually the same as the print ISSN."
+      },
+      {
+        "name": "issn",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "The ISSNs used by this venue. Many publications have multiple ISSNs (see above), so ISSN-L should be used when possible."
+      },
+      {
+        "name": "display_name",
+        "type": "STRING",
+        "description": "The name of the venue."
+      },
+      {
+        "name": "publisher",
+        "type": "STRING",
+        "description": "The name of this venue's publisher. Publisher is a tricky category, as journals often change publishers, publishers merge, publishers have subsidiaries (\"imprints\"), and of course no one is consistent in their naming. In the future, we plan to roll out support for a more structured publisher field, but for now it's just a string."
+      },
+      {
+        "name": "type",
+        "type": "STRING",
+        "description": ""
+      },
+      {
+        "name": "url",
+        "type": "STRING",
+        "description": "The URL where you can access this work."
+      },
+      {
+        "name": "is_oa",
+        "type": "BOOLEAN",
+        "description": "Set to true if the work hosted here can be read for free, without registration."
+      },
+      {
+        "name": "version",
+        "type": "STRING",
+        "description": "The version of the work, based on the DRIVER Guidelines versioning scheme. Possible values are: -publishedVersion: The document’s version of record. This is the most authoritative version. -acceptedVersion: The document after having completed peer review and being officially accepted for publication. It will lack publisher formatting, but the content should be interchangeable with the that of the publishedVersion. -submittedVersion: the document as submitted to the publisher by the authors, but before peer-review. Its content may differ significantly from that of the accepted article."
+      },
+      {
+        "name": "license",
+        "type": "STRING",
+        "description": "The license applied to this work at this host. Most toll-access works don't have an explicit license (they're under \"all rights reserved\" copyright), so this field generally has content only if is_oa is true."
+      }
+    ]
+  },
+  {
+    "name": "referenced_works",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "OpenAlex IDs for works that this work cites. These are citations that go from this work out to another work: This work ➞ Other works."
+  },
+  {
+    "name": "abstract_inverted_index",
+    "type": "RECORD",
+    "description": "The abstract of the work, as an inverted index, which encodes information about the abstract's words and their positions within the text. Like Microsoft Academic Graph, OpenAlex doesn't include plaintext abstracts due to legal constraints.",
+    "fields": [
+      {
+        "name": "keys",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "Custom field created by COKI. Originally each word in the abstract was a key and the indices of where this word occurred inside the abstract the corresponding value."
+      },
+      {
+        "name": "values",
+        "type": "STRING",
+        "mode": "REPEATED",
+        "description": "Custom field created by COKI. Originally each word in the abstract was a key and the indices of where this word occurred inside the abstract the corresponding value."
+      }
+    ]
+  },
+  {
+    "name": "related_works",
+    "type": "STRING",
+    "mode": "REPEATED",
+    "description": "OpenAlex IDs for works related to this work. "
+  },
+  {
+    "name": "cited_by_api_url",
+    "type": "STRING",
+    "description": "todo"
+  },
+  {
+    "name": "counts_by_year",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "todo",
+    "fields": [
+      {
+        "name": "year",
+        "type": "INTEGER",
+        "description": ""
+      },
+      {
+        "name": "works_count",
+        "type": "INTEGER",
+        "description": "todo"
+      },
+      {
+        "name": "cited_by_count",
+        "type": "INTEGER",
+        "description": "todo"
+      }
+    ]
+  },
+  {
+    "name": "updated_date",
+    "type": "STRING",
+    "description": "The last time anything in this Work object changed, expressed as an ISO 8601 date string. This date is updated for any change at all, including increases in various counts."
+  },
+  {
+    "name": "created_date",
+    "type": "STRING",
+    "description": "The date this Work object was created in the OpenAlex dataset, expressed as an ISO 8601 date string."
+  }
+]

--- a/academic_observatory_workflows/workflows/crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_events_telescope.py
@@ -226,6 +226,7 @@ class CrossrefEventsTelescope(StreamTelescope):
         max_threads: int = min(32, os.cpu_count() + 4),
         max_processes: int = os.cpu_count(),
         workflow_id: int = None,
+        dataset_type_id: str = DAG_ID,
     ):
         """Construct a CrossrefEventsTelescope instance.
 
@@ -265,6 +266,7 @@ class CrossrefEventsTelescope(StreamTelescope):
             batch_load=batch_load,
             airflow_vars=airflow_vars,
             workflow_id=workflow_id,
+            dataset_type_id=dataset_type_id,
             load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
         self.mailto = mailto

--- a/academic_observatory_workflows/workflows/crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_events_telescope.py
@@ -28,6 +28,7 @@ import requests
 from airflow.exceptions import AirflowSkipException
 from tenacity import RetryError, retry, stop_after_attempt, wait_exponential, wait_fixed
 
+from academic_observatory_workflows.api_type_ids import DatasetTypeId
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.url_utils import get_user_agent
@@ -226,7 +227,7 @@ class CrossrefEventsTelescope(StreamTelescope):
         max_threads: int = min(32, os.cpu_count() + 4),
         max_processes: int = os.cpu_count(),
         workflow_id: int = None,
-        dataset_type_id: str = DAG_ID,
+        dataset_type_id: str = DatasetTypeId.crossref_events,
     ):
         """Construct a CrossrefEventsTelescope instance.
 

--- a/academic_observatory_workflows/workflows/crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_events_telescope.py
@@ -213,6 +213,7 @@ class CrossrefEventsTelescope(StreamTelescope):
 
     def __init__(
         self,
+        workflow_id: int,
         dag_id: str = DAG_ID,
         start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
         schedule_interval: str = "@weekly",
@@ -226,7 +227,6 @@ class CrossrefEventsTelescope(StreamTelescope):
         mailto: str = "aniek.roelofs@curtin.edu.au",
         max_threads: int = min(32, os.cpu_count() + 4),
         max_processes: int = os.cpu_count(),
-        workflow_id: int = None,
         dataset_type_id: str = DatasetTypeId.crossref_events,
     ):
         """Construct a CrossrefEventsTelescope instance.

--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -37,7 +37,11 @@ from google.cloud import bigquery, storage
 
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowVars
-from observatory.platform.utils.gc_utils import aws_to_google_cloud_storage_transfer, upload_file_to_cloud_storage
+from observatory.platform.utils.gc_utils import (
+    aws_to_google_cloud_storage_transfer,
+    upload_file_to_cloud_storage,
+    bq_delete_old_rows,
+)
 from observatory.platform.utils.proc_utils import wait_for_process
 from observatory.platform.utils.release_utils import (
     add_dataset_release,
@@ -46,7 +50,7 @@ from observatory.platform.utils.release_utils import (
     get_latest_dataset_release,
     is_first_release,
 )
-from observatory.platform.utils.workflow_utils import blob_name, bq_append_from_file, bq_delete_old_rows
+from observatory.platform.utils.workflow_utils import blob_name, bq_append_from_file
 from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,

--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -36,6 +36,7 @@ from dateutil import tz
 from google.cloud import bigquery, storage
 
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
+from academic_observatory_workflows.api_type_ids import DatasetTypeId
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import (
     aws_to_google_cloud_storage_transfer,
@@ -329,7 +330,7 @@ class OpenAlexTelescope(StreamTelescope):
         airflow_conns: List = None,
         max_processes: int = os.cpu_count(),
         workflow_id: int = None,
-        dataset_type_id: str = "openalex",
+        dataset_type_id: str = DatasetTypeId.openalex,
     ):
         """Construct an OpenAlexTelescope instance.
 

--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -39,13 +39,14 @@ from academic_observatory_workflows.config import schema_folder as default_schem
 from observatory.platform.utils.airflow_utils import AirflowVars
 from observatory.platform.utils.gc_utils import aws_to_google_cloud_storage_transfer, upload_file_to_cloud_storage
 from observatory.platform.utils.proc_utils import wait_for_process
-from observatory.platform.utils.release_utils import add_dataset_release, get_dataset_releases, get_datasets, \
-    get_latest_dataset_release, is_first_release
-from observatory.platform.utils.workflow_utils import (
-    blob_name,
-    bq_append_from_file,
-    bq_delete_old_rows
+from observatory.platform.utils.release_utils import (
+    add_dataset_release,
+    get_dataset_releases,
+    get_datasets,
+    get_latest_dataset_release,
+    is_first_release,
 )
+from observatory.platform.utils.workflow_utils import blob_name, bq_append_from_file, bq_delete_old_rows
 from observatory.platform.workflows.stream_telescope import (
     StreamRelease,
     StreamTelescope,
@@ -54,13 +55,13 @@ from observatory.platform.workflows.stream_telescope import (
 
 class OpenAlexRelease(StreamRelease):
     def __init__(
-            self,
-            dag_id: str,
-            workflow_id: int,
-            start_date: pendulum.DateTime,
-            end_date: pendulum.DateTime,
-            first_release: bool,
-            max_processes: int,
+        self,
+        dag_id: str,
+        workflow_id: int,
+        start_date: pendulum.DateTime,
+        end_date: pendulum.DateTime,
+        first_release: bool,
+        max_processes: int,
     ):
         """Construct a OpenAlexRelease instance
 
@@ -72,8 +73,7 @@ class OpenAlexRelease(StreamRelease):
         :param max_processes: max processes for transforming files.
         """
         super().__init__(
-            dag_id, start_date, end_date, first_release, download_files_regex=".*.gz",
-            transform_files_regex=".*.gz"
+            dag_id, start_date, end_date, first_release, download_files_regex=".*.gz", transform_files_regex=".*.gz"
         )
         self.max_processes = max_processes
         self.workflow_id = workflow_id
@@ -147,7 +147,7 @@ class OpenAlexRelease(StreamRelease):
 
         updated_entities_count = 0
         with open(self.transfer_manifest_path_unchanged, "w") as f_unchanged, open(
-                self.transfer_manifest_path_transform, "w"
+            self.transfer_manifest_path_transform, "w"
         ) as f_transform:
             for entity in entities:
                 manifest_obj = s3client.get_object(Bucket=OpenAlexTelescope.AWS_BUCKET, Key=f"data/{entity}/manifest")
@@ -179,11 +179,11 @@ class OpenAlexRelease(StreamRelease):
 
         # Transfer files that are ready to load directly (unchanged) into BQ to both download and transform bucket,
         # transfer files that need to be transformed first only to download bucket.
-        transfers = [{"manifest": self.transfer_manifest_path_unchanged, "bucket": self.download_bucket,
-                      "subdir": "unchanged/"},
-                     {"manifest": self.transfer_manifest_path_unchanged, "bucket": self.transform_bucket, "subdir": ""},
-                     {"manifest": self.transfer_manifest_path_transform, "bucket": self.download_bucket,
-                      "subdir": "transform/"}]
+        transfers = [
+            {"manifest": self.transfer_manifest_path_unchanged, "bucket": self.download_bucket, "subdir": "unchanged/"},
+            {"manifest": self.transfer_manifest_path_unchanged, "bucket": self.transform_bucket, "subdir": ""},
+            {"manifest": self.transfer_manifest_path_transform, "bucket": self.download_bucket, "subdir": "transform/"},
+        ]
         total_count = 0
         for transfer in transfers:
             success = False
@@ -276,13 +276,13 @@ class OpenAlexRelease(StreamRelease):
                 future.result()
 
     def get_update_date(self) -> Dict[datetime]:
-        """ Get the last update date for the different entities from the manifest records.
+        """Get the last update date for the different entities from the manifest records.
 
         :return: A dictionary with last update date for each entity
         """
         lines = []
         with open(self.transfer_manifest_path_unchanged, "r") as f_unchanged, open(
-                self.transfer_manifest_path_transform, "r"
+            self.transfer_manifest_path_transform, "r"
         ) as f_transform:
             lines += f_unchanged.readlines()
             lines += f_transform.readlines()
@@ -308,19 +308,19 @@ class OpenAlexTelescope(StreamTelescope):
     AIRFLOW_CONN_AWS = "openalex"
 
     def __init__(
-            self,
-            dag_id: str = DAG_ID,
-            start_date: pendulum.DateTime = pendulum.datetime(2021, 12, 1),
-            schedule_interval: str = "@weekly",
-            dataset_id: str = "openalex",
-            dataset_description: str = "The OpenAlex dataset: https://docs.openalex.org/about-the-data",
-            queue: str = "remote_queue",
-            merge_partition_field: str = "id",
-            schema_folder: str = os.path.join(default_schema_folder(), "openalex"),
-            airflow_vars: List = None,
-            airflow_conns: List = None,
-            max_processes: int = os.cpu_count(),
-            workflow_id: int = None,
+        self,
+        dag_id: str = DAG_ID,
+        start_date: pendulum.DateTime = pendulum.datetime(2021, 12, 1),
+        schedule_interval: str = "@weekly",
+        dataset_id: str = "openalex",
+        dataset_description: str = "The OpenAlex dataset: https://docs.openalex.org/about-the-data",
+        queue: str = "remote_queue",
+        merge_partition_field: str = "id",
+        schema_folder: str = os.path.join(default_schema_folder(), "openalex"),
+        airflow_vars: List = None,
+        airflow_conns: List = None,
+        max_processes: int = os.cpu_count(),
+        workflow_id: int = None,
     ):
         """Construct an OpenAlexTelescope instance.
 
@@ -480,7 +480,7 @@ class OpenAlexTelescope(StreamTelescope):
                 table_description=table_description,
                 partition=True,
                 partition_type=bigquery.TimePartitioningType.DAY,
-                partition_decorator=release.end_date.format('YYYYMMDD'),
+                partition_decorator=release.end_date.format("YYYYMMDD"),
                 **self.load_bigquery_table_kwargs,
             )
 
@@ -512,8 +512,9 @@ class OpenAlexTelescope(StreamTelescope):
         """
 
         start_date, end_date, first_release = self.get_release_info(**kwargs)
-        release = OpenAlexRelease(self.dag_id, self.workflow_id, start_date, end_date, first_release,
-                                  self.max_processes)
+        release = OpenAlexRelease(
+            self.dag_id, self.workflow_id, start_date, end_date, first_release, self.max_processes
+        )
         return release
 
     def write_transfer_manifest(self, release: OpenAlexRelease, **kwargs):

--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -318,6 +318,7 @@ class OpenAlexTelescope(StreamTelescope):
 
     def __init__(
         self,
+        workflow_id: int,
         dag_id: str = DAG_ID,
         start_date: pendulum.DateTime = pendulum.datetime(2021, 12, 1),
         schedule_interval: str = "@weekly",
@@ -329,7 +330,6 @@ class OpenAlexTelescope(StreamTelescope):
         airflow_vars: List = None,
         airflow_conns: List = None,
         max_processes: int = os.cpu_count(),
-        workflow_id: int = None,
         dataset_type_id: str = DatasetTypeId.openalex,
     ):
         """Construct an OpenAlexTelescope instance.

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -246,6 +246,7 @@ class OrcidTelescope(StreamTelescope):
 
     def __init__(
         self,
+        workflow_id: int,
         dag_id: str = DAG_ID,
         start_date: pendulum.DateTime = pendulum.datetime(2018, 5, 14),
         schedule_interval: str = "@weekly",
@@ -259,7 +260,6 @@ class OrcidTelescope(StreamTelescope):
         airflow_vars: List = None,
         airflow_conns: List = None,
         max_processes: int = min(32, os.cpu_count() + 4),
-        workflow_id: int = None,
         dataset_type_id: str = DatasetTypeId.orcid,
     ):
         """Construct an OrcidTelescope instance.

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -259,6 +259,7 @@ class OrcidTelescope(StreamTelescope):
         airflow_conns: List = None,
         max_processes: int = min(32, os.cpu_count() + 4),
         workflow_id: int = None,
+        dataset_type_id: str = DAG_ID,
     ):
         """Construct an OrcidTelescope instance.
 
@@ -309,6 +310,7 @@ class OrcidTelescope(StreamTelescope):
             airflow_conns=airflow_conns,
             batch_load=batch_load,
             workflow_id=workflow_id,
+            dataset_type_id=dataset_type_id,
             load_bigquery_table_kwargs={"ignore_unknown_values": True},
         )
         self.max_processes = max_processes

--- a/academic_observatory_workflows/workflows/orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/orcid_telescope.py
@@ -35,6 +35,7 @@ from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.hooks.base_hook import BaseHook
 from airflow.models.variable import Variable
 
+from academic_observatory_workflows.api_type_ids import DatasetTypeId
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.airflow_utils import AirflowVars
@@ -259,7 +260,7 @@ class OrcidTelescope(StreamTelescope):
         airflow_conns: List = None,
         max_processes: int = min(32, os.cpu_count() + 4),
         workflow_id: int = None,
-        dataset_type_id: str = DAG_ID,
+        dataset_type_id: str = DatasetTypeId.orcid,
     ):
         """Construct an OrcidTelescope instance.
 

--- a/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_events_telescope.py
@@ -148,7 +148,7 @@ class TestCrossrefEventsTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        dag = CrossrefEventsTelescope().make_dag()
+        dag = CrossrefEventsTelescope(workflow_id=0).make_dag()
         self.assert_dag_structure(
             {
                 "check_dependencies": ["download"],

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -21,6 +21,7 @@ import json
 import os
 from subprocess import Popen
 from unittest.mock import Mock, call, patch
+from dateutil import tz
 
 import pendulum
 from airflow.exceptions import AirflowException, AirflowSkipException
@@ -75,54 +76,52 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         self.entities = {
             "authors": {
                 "download_path": test_fixtures_folder("openalex", "authors.jsonl"),
-                "bucket": "transform_bucket",
             },
             "concepts": {
                 "download_path": test_fixtures_folder("openalex", "concepts.jsonl"),
-                "bucket": "download_bucket",
                 "download_hash": "14bd0919",
                 "transform_hash": "4bb6fe07",
             },
             "institutions": {
                 "download_path": test_fixtures_folder("openalex", "institutions.jsonl"),
-                "bucket": "download_bucket",
                 "download_hash": "b23bb91c",
                 "transform_hash": "a9cfff73",
             },
             "venues": {
                 "download_path": test_fixtures_folder("openalex", "venues.jsonl"),
-                "bucket": "transform_bucket",
             },
             "works": {
                 "download_path": test_fixtures_folder("openalex", "works.jsonl"),
-                "bucket": "download_bucket",
                 "download_hash": "806d7995",
                 "transform_hash": "0a783ffc",
             },
         }
-        self.table_bytes = {
-            "Author": 3965,
-            "Author_partitions": 3965,
-            "Concept": 3947,
-            "Concept_partitions": 3947,
-            "Institution": 3259,
-            "Institution_partitions": 3259,
-            "Venue": 2108,
-            "Venue_partitions": 2108,
-            "Work": 11804,
-            "Work_partitions": 11804,
-        }
+
         self.first_run = {
             "execution_date": pendulum.datetime(year=2022, month=1, day=1),
             "manifest_date": "2021-12-17",
-            "manifest_download_hash": "9ab1f7c9eb0adbdaf07baaf8b97a110e",
-            "manifest_transform_hash": "6400ca22b963599af6bad9db030fe11a",
+            "manifest_unchanged_hash": "6400ca22b963599af6bad9db030fe11a",
+            "manifest_transform_hash": "9ab1f7c9eb0adbdaf07baaf8b97a110e",
+            "table_bytes": {
+                "Author": 3965,
+                "Concept": 3947,
+                "Institution": 3259,
+                "Venue": 2108,
+                "Work": 11804,
+            }
         }
         self.second_run = {
             "execution_date": pendulum.datetime(year=2022, month=2, day=1),
             "manifest_date": "2022-01-17",
-            "manifest_download_hash": "f4cea919d06caa0811ad5976bf98986a",
-            "manifest_transform_hash": "50e2eff06007a32c4394df8df7f5e907",
+            "manifest_unchanged_hash": "50e2eff06007a32c4394df8df7f5e907",
+            "manifest_transform_hash": "f4cea919d06caa0811ad5976bf98986a",
+            "table_bytes": {
+                "Author": 7930,
+                "Concept": 7894,
+                "Institution": 6518,
+                "Venue": 4216,
+                "Work": 23608,
+            }
         }
 
         # API environment
@@ -135,8 +134,6 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         self.org_name = "Curtin University"
 
     def setup_api(self):
-        dt = pendulum.now("UTC")
-
         name = "OpenAlex Telescope"
         workflow_type = WorkflowType(name=name, type_id=OpenAlexTelescope.DAG_ID)
         self.api.put_workflow_type(workflow_type)
@@ -163,22 +160,37 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         )
         self.api.put_table_type(table_type)
 
-        dataset_type = DatasetType(
-            type_id="openalex",
-            name="ds type",
+        dataset_type1 = DatasetType(
+            type_id="openalex_institution",
+            name="OpenAlex Institution",
             extra={},
             table_type=TableType(id=1),
         )
-        self.api.put_dataset_type(dataset_type)
+        dataset_type2 = DatasetType(
+            type_id="openalex_author",
+            name="OpenAlex Author",
+            extra={},
+            table_type=TableType(id=1),
+        )
+        self.api.put_dataset_type(dataset_type1)
+        self.api.put_dataset_type(dataset_type2)
 
-        dataset = Dataset(
-            name="OpenAlex Dataset",
+        dataset1 = Dataset(
+            name="OpenAlex Institution Dataset",
             address="project.dataset.table",
             service="bigquery",
             workflow=Workflow(id=1),
             dataset_type=DatasetType(id=1),
         )
-        self.api.put_dataset(dataset)
+        dataset2 = Dataset(
+            name="OpenAlex Author Dataset",
+            address="project.dataset.table",
+            service="bigquery",
+            workflow=Workflow(id=1),
+            dataset_type=DatasetType(id=2),
+        )
+        self.api.put_dataset(dataset1)
+        self.api.put_dataset(dataset2)
 
     def setup_connections(self, env):
         # Add Observatory API connection
@@ -198,11 +210,10 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 "transfer": ["download_transferred"],
                 "download_transferred": ["transform"],
                 "transform": ["upload_transformed"],
-                "upload_transformed": ["bq_load_partition"],
-                "bq_load_partition": ["bq_delete_old"],
-                "bq_delete_old": ["bq_append_new"],
-                "bq_append_new": ["cleanup"],
-                "cleanup": ["add_new_dataset_releases"],
+                "upload_transformed": ["bq_append_new"],
+                "bq_append_new": ["bq_delete_old"],
+                "bq_delete_old": ["bq_create_snapshot"],
+                "bq_create_snapshot": ["add_new_dataset_releases"],
                 "add_new_dataset_releases": [],
             },
             dag,
@@ -230,7 +241,6 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         """Test the OpenAlex telescope end to end.
         :return: None.
         """
-
         m_makeapi.return_value = self.api
 
         # Setup Observatory environment
@@ -252,20 +262,20 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             env.add_connection(conn)
 
             run = self.first_run
-            with env.create_dag_run(dag, run["execution_date"]) as dag_run:
+            with env.create_dag_run(dag, run["execution_date"]):
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
                 start_date, end_date, first_release = telescope.get_release_info(
                     dag=dag,
-                    data_interval_end=datetime.datetime(2021, 12, 26),
                 )
                 self.assertEqual(dag.default_args["start_date"], start_date)
-                self.assertEqual(pendulum.datetime(2021, 12, 26), end_date)
+                self.assertEqual(pendulum.datetime(2022, 1, 2), end_date)
                 self.assertTrue(first_release)
 
                 # Use release info for other tasks
                 release = OpenAlexRelease(
                     telescope.dag_id,
+                    telescope.workflow_id,
                     start_date,
                     end_date,
                     first_release,
@@ -283,23 +293,25 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
                 # Test write transfer manifest task
                 env.run_task(telescope.write_transfer_manifest.__name__)
-                print(release.transfer_manifest_path_download)
-                print(run["manifest_download_hash"])
                 self.assert_file_integrity(
-                    release.transfer_manifest_path_download, run["manifest_download_hash"], "md5"
+                    release.transfer_manifest_path_unchanged, run["manifest_unchanged_hash"], "md5"
                 )
                 self.assert_file_integrity(
                     release.transfer_manifest_path_transform, run["manifest_transform_hash"], "md5"
                 )
 
+                # # Test upload transfer manifest task
+                # env.run_task(telescope.upload_transfer_manifest.__name__)
+
                 # Test transfer task
                 mock_transfer.reset_mock()
                 mock_transfer.return_value = True, 2
                 env.run_task(telescope.transfer.__name__)
-                self.assertEqual(2, mock_transfer.call_count)
+                self.assertEqual(3, mock_transfer.call_count)
                 try:
                     self.assertTupleEqual(mock_transfer.call_args_list[0][0], (conn.login, conn.password))
                     self.assertTupleEqual(mock_transfer.call_args_list[1][0], (conn.login, conn.password))
+                    self.assertTupleEqual(mock_transfer.call_args_list[2][0], (conn.login, conn.password))
                 except AssertionError:
                     raise AssertionError("AWS key id and secret not passed correctly to transfer function")
                 self.assertDictEqual(
@@ -307,13 +319,12 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                     {
                         "aws_bucket": OpenAlexTelescope.AWS_BUCKET,
                         "include_prefixes": [
-                            f"data/concepts/updated_date={run['manifest_date']}/0000_part_00.gz",
-                            f"data/institutions/updated_date={run['manifest_date']}/0000_part_00.gz",
-                            f"data/works/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/authors/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/venues/updated_date={run['manifest_date']}/0000_part_00.gz",
                         ],
                         "gc_project_id": self.project_id,
                         "gc_bucket": release.download_bucket,
-                        "gc_bucket_path": f"telescopes/{release.dag_id}/{release.release_id}/",
+                        "gc_bucket_path": f"telescopes/{release.dag_id}/{release.release_id}/unchanged/",
                         "description": f"Transfer OpenAlex data from Airflow telescope to {release.download_bucket}",
                     },
                 )
@@ -331,15 +342,39 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                         "description": f"Transfer OpenAlex data from Airflow telescope to {release.transform_bucket}",
                     },
                 )
+                self.assertDictEqual(
+                    mock_transfer.call_args_list[2][1],
+                    {
+                        "aws_bucket": OpenAlexTelescope.AWS_BUCKET,
+                        "include_prefixes": [
+                            f"data/concepts/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/institutions/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/works/updated_date={run['manifest_date']}/0000_part_00.gz",
+                        ],
+                        "gc_project_id": self.project_id,
+                        "gc_bucket": release.download_bucket,
+                        "gc_bucket_path": f"telescopes/{release.dag_id}/{release.release_id}/transform/",
+                        "description": f"Transfer OpenAlex data from Airflow telescope to {release.download_bucket}",
+                    },
+                )
 
                 # Upload files to bucket, to mock transfer
                 for entity, info in self.entities.items():
-                    blob = f"telescopes/{release.dag_id}/{release.release_id}/data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
                     gzip_path = f"{entity}.jsonl.gz"
                     with open(info["download_path"], "rb") as f_in, gzip.open(gzip_path, "wb") as f_out:
                         f_out.writelines(f_in)
 
-                    upload_file_to_cloud_storage(getattr(release, info["bucket"]), blob, gzip_path)
+                    if entity == "authors" or entity == "venues":
+                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/unchanged/" \
+                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        transform_blob = f"telescopes/{release.dag_id}/{release.release_id}/" \
+                                         f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
+                        upload_file_to_cloud_storage(release.transform_bucket, transform_blob, gzip_path)
+                    else:
+                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/transform/" \
+                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
 
                 # Test that file was downloaded
                 env.run_task(telescope.download_transferred.__name__)
@@ -373,38 +408,46 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Get bq load info for BQ tasks
                 bq_load_info = telescope.get_bq_load_info(release)
 
-                # Test that load partition task is skipped for the first release
-                ti = env.run_task(telescope.bq_load_partition.__name__)
-                self.assertEqual(ti.state, State.SUCCESS)
+                # Test append new creates table
+                env.run_task(telescope.bq_append_new.__name__)
+                for _, table, _ in bq_load_info:
+                    table_id = f"{self.project_id}.{telescope.dataset_id}.{table}"
+                    expected_bytes = run["table_bytes"][table]
+                    self.assert_table_bytes(table_id, expected_bytes)
 
                 # Test delete old task is skipped for the first release
                 with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
                     ti = env.run_task(telescope.bq_delete_old.__name__)
                 self.assertEqual(ti.state, State.SUCCESS)
 
-                # Test append new creates table
-                env.run_task(telescope.bq_append_new.__name__)
-                for _, main_table_id, _ in bq_load_info:
-                    table_id = f"{self.project_id}.{telescope.dataset_id}.{main_table_id}"
-                    expected_bytes = self.table_bytes[main_table_id]
-                    self.assert_table_bytes(table_id, expected_bytes)
+                # Test create bigquery snapshot
+                ti = env.run_task(telescope.bq_create_snapshot.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
 
-                # Test that all telescope data deleted
+
+                # Test adding of dataset releases as well as cleanup
                 download_folder, extract_folder, transform_folder = (
                     release.download_folder,
                     release.extract_folder,
                     release.transform_folder,
                 )
-                env.run_task(telescope.cleanup.__name__)
-                self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
-                # add_dataset_release_task
-                dataset_releases = get_dataset_releases(dataset_id=1)
-                self.assertEqual(len(dataset_releases), 0)
-                ti = env.run_task("add_new_dataset_releases")
+                institution_dataset_releases = get_dataset_releases(dataset_id=1)
+                author_dataset_releases = get_dataset_releases(dataset_id=2)
+                self.assertListEqual([], institution_dataset_releases)
+                self.assertListEqual([], author_dataset_releases)
+
+                ti = env.run_task(telescope.add_new_dataset_releases.__name__)
                 self.assertEqual(ti.state, State.SUCCESS)
-                dataset_releases = get_dataset_releases(dataset_id=1)
-                self.assertEqual(len(dataset_releases), 1)
+
+                institution_dataset_releases = get_dataset_releases(dataset_id=1)
+                author_dataset_releases = get_dataset_releases(dataset_id=2)
+                self.assertEqual(1, len(institution_dataset_releases))
+                self.assertEqual(1, len(author_dataset_releases))
+                self.assertEqual(pendulum.from_format("2021-12-17", "YYYY-MM-DD"), institution_dataset_releases[
+                    0].end_date)
+
+                self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
             run = self.second_run
             with env.create_dag_run(dag, run["execution_date"]) as dag_run:
@@ -412,15 +455,15 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 env.run_task(telescope.check_dependencies.__name__)
                 start_date, end_date, first_release = telescope.get_release_info(
                     dag=dag,
-                    data_interval_end=datetime.datetime(2022, 1, 30),
                 )
                 self.assertEqual(release.end_date, start_date)
-                self.assertEqual(pendulum.datetime(2022, 1, 30), end_date)
+                self.assertEqual(pendulum.datetime(2022, 2, 6), end_date)
                 self.assertFalse(first_release)
 
                 # Use release info for other tasks
                 release = OpenAlexRelease(
                     telescope.dag_id,
+                    telescope.workflow_id,
                     start_date,
                     end_date,
                     first_release,
@@ -439,34 +482,38 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Test write transfer manifest task
                 env.run_task(telescope.write_transfer_manifest.__name__)
                 self.assert_file_integrity(
-                    release.transfer_manifest_path_download, run["manifest_download_hash"], "md5"
+                    release.transfer_manifest_path_unchanged, run["manifest_unchanged_hash"], "md5"
                 )
                 self.assert_file_integrity(
                     release.transfer_manifest_path_transform, run["manifest_transform_hash"], "md5"
                 )
 
+                # # Test upload transfer manifest task
+                # env.run_task(telescope.upload_transfer_manifest.__name__)
+
                 # Test transfer task
                 mock_transfer.reset_mock()
                 mock_transfer.return_value = True, 2
                 env.run_task(telescope.transfer.__name__)
-                self.assertEqual(2, mock_transfer.call_count)
+                self.assertEqual(3, mock_transfer.call_count)
                 try:
                     self.assertTupleEqual(mock_transfer.call_args_list[0][0], (conn.login, conn.password))
                     self.assertTupleEqual(mock_transfer.call_args_list[1][0], (conn.login, conn.password))
+                    self.assertTupleEqual(mock_transfer.call_args_list[2][0], (conn.login, conn.password))
                 except AssertionError:
                     raise AssertionError("AWS key id and secret not passed correctly to transfer function")
+
                 self.assertDictEqual(
                     mock_transfer.call_args_list[0][1],
                     {
                         "aws_bucket": OpenAlexTelescope.AWS_BUCKET,
                         "include_prefixes": [
-                            f"data/concepts/updated_date={run['manifest_date']}/0000_part_00.gz",
-                            f"data/institutions/updated_date={run['manifest_date']}/0000_part_00.gz",
-                            f"data/works/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/authors/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/venues/updated_date={run['manifest_date']}/0000_part_00.gz",
                         ],
                         "gc_project_id": self.project_id,
                         "gc_bucket": release.download_bucket,
-                        "gc_bucket_path": f"telescopes/{release.dag_id}/{release.release_id}/",
+                        "gc_bucket_path": f"telescopes/{release.dag_id}/{release.release_id}/unchanged/",
                         "description": f"Transfer OpenAlex data from Airflow telescope to {release.download_bucket}",
                     },
                 )
@@ -484,15 +531,39 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                         "description": f"Transfer OpenAlex data from Airflow telescope to {release.transform_bucket}",
                     },
                 )
+                self.assertDictEqual(
+                    mock_transfer.call_args_list[2][1],
+                    {
+                        "aws_bucket": OpenAlexTelescope.AWS_BUCKET,
+                        "include_prefixes": [
+                            f"data/concepts/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/institutions/updated_date={run['manifest_date']}/0000_part_00.gz",
+                            f"data/works/updated_date={run['manifest_date']}/0000_part_00.gz",
+                        ],
+                        "gc_project_id": self.project_id,
+                        "gc_bucket": release.download_bucket,
+                        "gc_bucket_path": f"telescopes/{release.dag_id}/{release.release_id}/transform/",
+                        "description": f"Transfer OpenAlex data from Airflow telescope to {release.download_bucket}",
+                    },
+                )
 
                 # Upload files to bucket, to mock transfer
                 for entity, info in self.entities.items():
-                    blob = f"telescopes/{release.dag_id}/{release.release_id}/data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
                     gzip_path = f"{entity}.jsonl.gz"
                     with open(info["download_path"], "rb") as f_in, gzip.open(gzip_path, "wb") as f_out:
                         f_out.writelines(f_in)
 
-                    upload_file_to_cloud_storage(getattr(release, info["bucket"]), blob, gzip_path)
+                    if entity == "authors" or entity == "venues":
+                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/unchanged/" \
+                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        transform_blob = f"telescopes/{release.dag_id}/{release.release_id}/" \
+                                         f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
+                        upload_file_to_cloud_storage(release.transform_bucket, transform_blob, gzip_path)
+                    else:
+                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/transform/" \
+                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
 
                 # Test that file was downloaded
                 env.run_task(telescope.download_transferred.__name__)
@@ -526,55 +597,69 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Get bq load info for BQ tasks
                 bq_load_info = telescope.get_bq_load_info(release)
 
-                # Test that partition is loaded
-                ti = env.run_task(telescope.bq_load_partition.__name__)
-                for _, _, partition_table_id in bq_load_info:
-                    table_id = f"{self.project_id}.{telescope.dataset_id}.{partition_table_id}"
-                    expected_bytes = self.table_bytes[partition_table_id]
-                    self.assert_table_bytes(table_id, expected_bytes)
-
-                # Test that partition is deleted from main table
-                with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
-                    ti = env.run_task(telescope.bq_delete_old.__name__)
-                for _, main_table_id, _ in bq_load_info:
-                    table_id = f"{self.project_id}.{telescope.dataset_id}.{main_table_id}"
-                    expected_bytes = 0
-                    self.assert_table_bytes(table_id, expected_bytes)
-
                 # Test append new creates table
                 env.run_task(telescope.bq_append_new.__name__)
-                for _, main_table_id, _ in bq_load_info:
-                    table_id = f"{self.project_id}.{telescope.dataset_id}.{main_table_id}"
-                    expected_bytes = self.table_bytes[main_table_id]
+                for _, table, _ in bq_load_info:
+                    table_id = f"{self.project_id}.{telescope.dataset_id}.{table}"
+                    expected_bytes = run["table_bytes"][table]
                     self.assert_table_bytes(table_id, expected_bytes)
 
-                # Test that all telescope data deleted
+                # Test that old rows are deleted from table
+                with patch("observatory.platform.utils.gc_utils.bq_query_bytes_daily_limit_check"):
+                    env.run_task(telescope.bq_delete_old.__name__)
+                for _, table, _ in bq_load_info:
+                    table_id = f"{self.project_id}.{telescope.dataset_id}.{table}"
+                    expected_bytes = self.first_run["table_bytes"][table]
+                    self.assert_table_bytes(table_id, expected_bytes)
+
+                # Test create bigquery snapshot
+                ti = env.run_task(telescope.bq_create_snapshot.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                # Test adding of dataset releases and cleanup of local files
                 download_folder, extract_folder, transform_folder = (
                     release.download_folder,
                     release.extract_folder,
                     release.transform_folder,
                 )
-                env.run_task(telescope.cleanup.__name__)
+
+                institution_dataset_releases = get_dataset_releases(dataset_id=1)
+                author_dataset_releases = get_dataset_releases(dataset_id=2)
+                self.assertEqual(1, len(institution_dataset_releases))
+                self.assertEqual(1, len(author_dataset_releases))
+
+                ti = env.run_task(telescope.add_new_dataset_releases.__name__)
+                self.assertEqual(ti.state, State.SUCCESS)
+
+                institution_dataset_releases = get_dataset_releases(dataset_id=1)
+                author_dataset_releases = get_dataset_releases(dataset_id=2)
+                self.assertEqual(2, len(institution_dataset_releases))
+                self.assertEqual(2, len(author_dataset_releases))
+                self.assertEqual(pendulum.from_format("2022-1-17", "YYYY-MM-DD"), institution_dataset_releases[
+                    1].end_date)
+
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
-                # add_dataset_release_task
-                dataset_releases = get_dataset_releases(dataset_id=1)
-                self.assertEqual(len(dataset_releases), 1)
-                ti = env.run_task("add_new_dataset_releases")
-                self.assertEqual(ti.state, State.SUCCESS)
-                dataset_releases = get_dataset_releases(dataset_id=1)
-                self.assertEqual(len(dataset_releases), 2)
-
+    @patch("academic_observatory_workflows.workflows.openalex_telescope.get_dataset_releases")
+    @patch("academic_observatory_workflows.workflows.openalex_telescope.get_datasets")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.boto3.client")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.get_aws_conn_info")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.Variable.get")
-    def test_write_transfer_manifest(self, mock_variable_get, mock_aws_info, mock_boto3):
+    def test_write_transfer_manifest(self, mock_variable_get, mock_aws_info, mock_boto3, mock_get_datasets,
+                                     mock_get_releases):
         """Test write_transfer_manifest method of the OpenAlex release.
 
         :param mock_variable_get: Mock Airflow Variable get() method
         :param mock_boto3: Mock the boto3 client
         :return: None.
         """
+        from types import SimpleNamespace
+        mock_get_datasets.return_value = [SimpleNamespace(name="OpenAlex Author Dataset", id=1),
+                                          SimpleNamespace(name="OpenAlex Concept Dataset", id=2),
+                                          SimpleNamespace(name="OpenAlex Institution Dataset", id=3),
+                                          SimpleNamespace(name="OpenAlex Venue Dataset", id=4),
+                                          SimpleNamespace(name="OpenAlex Work Dataset", id=5)
+                                          ]
         mock_variable_get.return_value = "data"
         mock_aws_info.return_value = "key_id", "secret_key"
         # Mock response of get_object on last_modified file, mocking lambda file
@@ -585,24 +670,25 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 side_effect.append({"Body": StreamingBody(io.BytesIO(manifest_content), len(manifest_content))})
         mock_boto3().get_object.side_effect = side_effect
 
+        start_date = pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.tz.UTC)
+        end_date = pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.tz.UTC)
+
         with CliRunner().isolated_filesystem():
-            # Test with entries in manifest objects that are after start date
-            start_date = pendulum.DateTime(2022, 1, 1, tzinfo=pendulum.tz.UTC)
-            end_date = pendulum.DateTime(2022, 2, 1, tzinfo=pendulum.tz.UTC)
-            release = OpenAlexRelease("dag_id", start_date, end_date, False, 1)
+            # Test with entries in manifest objects that are after end date of latest release
+            mock_get_releases.return_value = [{"end_date": datetime.datetime(2021, 1, 1, tzinfo=tz.UTC)}]
+            release = OpenAlexRelease("dag_id", 1, start_date, end_date, False, 1)
 
             release.write_transfer_manifest()
             self.assert_file_integrity(
-                release.transfer_manifest_path_download, "42fb45119bd34709001fd6c90a6ef60e", "md5"
+                release.transfer_manifest_path_unchanged, "fe8442cd31fec1c335379033afebc1ea", "md5"
             ),
             self.assert_file_integrity(
-                release.transfer_manifest_path_transform, "fe8442cd31fec1c335379033afebc1ea", "md5"
+                release.transfer_manifest_path_transform, "42fb45119bd34709001fd6c90a6ef60e", "md5"
             )
 
-            # Test with entries in manifest objects that are before start date
-            start_date = pendulum.DateTime(2022, 3, 1, tzinfo=pendulum.tz.UTC)
-            end_date = pendulum.DateTime(2022, 4, 1, tzinfo=pendulum.tz.UTC)
-            release = OpenAlexRelease("dag_id", start_date, end_date, False, 1)
+            # Test with entries in manifest objects that are before end date of latest release
+            mock_get_releases.return_value = [{"end_date": datetime.datetime(2022, 2, 1, tzinfo=tz.UTC)}]
+            release = OpenAlexRelease("dag_id", 1, start_date, end_date, False, 1)
 
             with self.assertRaises(AirflowSkipException):
                 release.write_transfer_manifest()
@@ -631,26 +717,34 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             # Create release
             start_date = pendulum.DateTime(2022, 1, 1)
             end_date = pendulum.DateTime(2022, 2, 1)
-            release = OpenAlexRelease("dag_id", start_date, end_date, False, 1)
+            release = OpenAlexRelease("dag_id", 1, start_date, end_date, False, 1)
 
             # Create transfer manifest files
-            with open(release.transfer_manifest_path_download, "w") as f:
+            with open(release.transfer_manifest_path_unchanged, "w") as f:
                 f.write('"prefix1"\n"prefix2"\n')
             with open(release.transfer_manifest_path_transform, "w") as f:
                 f.write("")
 
-            # Test succesful transfer with prefixes for download, no prefixes for transform
+            # Test successful transfer with prefixes for unchanged, no prefixes for transform
             release.transfer(max_retries=1)
-            mock_transfer.assert_called_once_with(
-                "key_id",
-                "secret_key",
-                aws_bucket=OpenAlexTelescope.AWS_BUCKET,
-                include_prefixes=["prefix1", "prefix2"],
-                gc_project_id="project_id",
-                gc_bucket="download-bucket",
-                gc_bucket_path="telescopes/dag_id/2022_01_01-2022_02_01/",
-                description="Transfer OpenAlex data from Airflow telescope to download-bucket",
-            )
+            self.assertDictEqual(
+                {"aws_bucket": OpenAlexTelescope.AWS_BUCKET,
+                "include_prefixes": ["prefix1", "prefix2"],
+                "gc_project_id": "project_id",
+                "gc_bucket": "download-bucket",
+                "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/unchanged/",
+                "description": "Transfer OpenAlex data from Airflow telescope to download-bucket"
+                 },
+                mock_transfer.call_args_list[0][1])
+            self.assertDictEqual(
+                {"aws_bucket": OpenAlexTelescope.AWS_BUCKET,
+                "include_prefixes": ["prefix1", "prefix2"],
+                "gc_project_id": "project_id",
+                "gc_bucket": "transform-bucket",
+                "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/",
+                "description": "Transfer OpenAlex data from Airflow telescope to transform-bucket"
+                 },
+                mock_transfer.call_args_list[1][1])
             mock_transfer.reset_mock()
 
             # Test failed transfer

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -100,7 +100,6 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
         self.first_run = {
             "execution_date": pendulum.datetime(year=2022, month=1, day=2),
-            "next_execution_date": pendulum.datetime(year=2022, month=1, day=9),
             "manifest_date": "2021-12-17",
             "manifest_unchanged_hash": "6400ca22b963599af6bad9db030fe11a",
             "manifest_transform_hash": "9ab1f7c9eb0adbdaf07baaf8b97a110e",
@@ -114,7 +113,6 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         }
         self.second_run = {
             "execution_date": pendulum.datetime(year=2022, month=1, day=9),
-            "next_execution_date": pendulum.datetime(year=2022, month=1, day=16),
             "manifest_date": "2022-01-17",
             "manifest_unchanged_hash": "50e2eff06007a32c4394df8df7f5e907",
             "manifest_transform_hash": "f4cea919d06caa0811ad5976bf98986a",
@@ -284,10 +282,11 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
                 start_date, end_date, first_release = telescope.get_release_info(
-                    dag=dag, data_interval_end=run["next_execution_date"]
+                    dag=dag,
+                    data_interval_end=pendulum.datetime(year=2021, month=12, day=26),
                 )
                 self.assertEqual(dag.default_args["start_date"], start_date)
-                self.assertEqual(run["next_execution_date"], end_date)
+                self.assertEqual(pendulum.datetime(year=2021, month=12, day=26), end_date)
                 self.assertTrue(first_release)
 
                 # Use release info for other tasks
@@ -484,10 +483,11 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Test that all dependencies are specified: no error should be thrown
                 env.run_task(telescope.check_dependencies.__name__)
                 start_date, end_date, first_release = telescope.get_release_info(
-                    dag=dag, data_interval_end=run["next_execution_date"]
+                    dag=dag,
+                    data_interval_end=pendulum.datetime(year=2022, month=1, day=2),
                 )
                 self.assertEqual(release.end_date, start_date)
-                self.assertEqual(run["next_execution_date"], end_date)
+                self.assertEqual(pendulum.datetime(year=2022, month=1, day=2), end_date)
                 self.assertFalse(first_release)
 
                 # Use release info for other tasks

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -31,6 +31,7 @@ from botocore.response import StreamingBody
 from click.testing import CliRunner
 from dateutil import tz
 
+from academic_observatory_workflows.api_type_ids import DatasetTypeId
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.openalex_telescope import (
     OpenAlexRelease,
@@ -162,19 +163,19 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         self.api.put_table_type(table_type)
 
         dataset_type1 = DatasetType(
-            type_id="openalex",
+            type_id=DatasetTypeId.openalex,
             name="OpenAlex",
             extra={},
             table_type=TableType(id=1),
         )
         dataset_type2 = DatasetType(
-            type_id="openalex_institution",
+            type_id=DatasetTypeId.openalex_institution,
             name="OpenAlex Institution",
             extra={},
             table_type=TableType(id=1),
         )
         dataset_type3 = DatasetType(
-            type_id="openalex_author",
+            type_id=DatasetTypeId.openalex_author,
             name="OpenAlex Author",
             extra={},
             table_type=TableType(id=1),

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -219,7 +219,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        dag = OpenAlexTelescope().make_dag()
+        dag = OpenAlexTelescope(workflow_id=0).make_dag()
         self.assert_dag_structure(
             {
                 "check_dependencies": ["write_transfer_manifest"],

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -720,7 +720,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             # Test with entries in manifest objects that are after end date of latest release
             mock_get_releases.return_value = [{"end_date": datetime.datetime(2021, 1, 1, tzinfo=tz.UTC)}]
-            release = OpenAlexRelease("dag_id", 1, start_date, end_date, False, 1)
+            release = OpenAlexRelease("dag_id", 1, "dataset_type", start_date, end_date, False, 1)
 
             release.write_transfer_manifest()
             self.assert_file_integrity(
@@ -732,7 +732,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
             # Test with entries in manifest objects that are before end date of latest release
             mock_get_releases.return_value = [{"end_date": datetime.datetime(2022, 2, 1, tzinfo=tz.UTC)}]
-            release = OpenAlexRelease("dag_id", 1, start_date, end_date, False, 1)
+            release = OpenAlexRelease("dag_id", 1, "dataset_type_id", start_date, end_date, False, 1)
 
             with self.assertRaises(AirflowSkipException):
                 release.write_transfer_manifest()
@@ -761,7 +761,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             # Create release
             start_date = pendulum.DateTime(2022, 1, 1)
             end_date = pendulum.DateTime(2022, 2, 1)
-            release = OpenAlexRelease("dag_id", 1, start_date, end_date, False, 1)
+            release = OpenAlexRelease("dag_id", 1, "dataset_type_id", start_date, end_date, False, 1)
 
             # Create transfer manifest files
             with open(release.transfer_manifest_path_unchanged, "w") as f:

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -109,7 +109,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 "Institution": 3259,
                 "Venue": 2108,
                 "Work": 11804,
-            }
+            },
         }
         self.second_run = {
             "execution_date": pendulum.datetime(year=2022, month=2, day=1),
@@ -122,7 +122,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 "Institution": 6518,
                 "Venue": 4216,
                 "Work": 23608,
-            }
+            },
         }
 
         # API environment
@@ -258,7 +258,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
             # Add connection
             conn = Connection(
-                conn_id=OpenAlexTelescope.AIRFLOW_CONN_AWS, uri='aws://UWLA41aAhdja:AJLD91saAJSKAL0AjAhkaka@'
+                conn_id=OpenAlexTelescope.AIRFLOW_CONN_AWS, uri="aws://UWLA41aAhdja:AJLD91saAJSKAL0AjAhkaka@"
             )
             env.add_connection(conn)
 
@@ -366,15 +366,21 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                         f_out.writelines(f_in)
 
                     if entity == "authors" or entity == "venues":
-                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/unchanged/" \
-                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
-                        transform_blob = f"telescopes/{release.dag_id}/{release.release_id}/" \
-                                         f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        download_blob = (
+                            f"telescopes/{release.dag_id}/{release.release_id}/unchanged/"
+                            f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        )
+                        transform_blob = (
+                            f"telescopes/{release.dag_id}/{release.release_id}/"
+                            f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        )
                         upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
                         upload_file_to_cloud_storage(release.transform_bucket, transform_blob, gzip_path)
                     else:
-                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/transform/" \
-                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        download_blob = (
+                            f"telescopes/{release.dag_id}/{release.release_id}/transform/"
+                            f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        )
                         upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
 
                 # Test that file was downloaded
@@ -444,8 +450,9 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 author_dataset_releases = get_dataset_releases(dataset_id=2)
                 self.assertEqual(1, len(institution_dataset_releases))
                 self.assertEqual(1, len(author_dataset_releases))
-                self.assertEqual(pendulum.from_format("2021-12-17", "YYYY-MM-DD"), institution_dataset_releases[
-                    0].end_date)
+                self.assertEqual(
+                    pendulum.from_format("2021-12-17", "YYYY-MM-DD"), institution_dataset_releases[0].end_date
+                )
 
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
@@ -554,15 +561,21 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                         f_out.writelines(f_in)
 
                     if entity == "authors" or entity == "venues":
-                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/unchanged/" \
-                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
-                        transform_blob = f"telescopes/{release.dag_id}/{release.release_id}/" \
-                                         f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        download_blob = (
+                            f"telescopes/{release.dag_id}/{release.release_id}/unchanged/"
+                            f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        )
+                        transform_blob = (
+                            f"telescopes/{release.dag_id}/{release.release_id}/"
+                            f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        )
                         upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
                         upload_file_to_cloud_storage(release.transform_bucket, transform_blob, gzip_path)
                     else:
-                        download_blob = f"telescopes/{release.dag_id}/{release.release_id}/transform/" \
-                                        f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        download_blob = (
+                            f"telescopes/{release.dag_id}/{release.release_id}/transform/"
+                            f"data/{entity}/updated_date={run['manifest_date']}/0000_part_00.gz"
+                        )
                         upload_file_to_cloud_storage(release.download_bucket, download_blob, gzip_path)
 
                 # Test that file was downloaded
@@ -635,8 +648,9 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 author_dataset_releases = get_dataset_releases(dataset_id=2)
                 self.assertEqual(2, len(institution_dataset_releases))
                 self.assertEqual(2, len(author_dataset_releases))
-                self.assertEqual(pendulum.from_format("2022-1-17", "YYYY-MM-DD"), institution_dataset_releases[
-                    1].end_date)
+                self.assertEqual(
+                    pendulum.from_format("2022-1-17", "YYYY-MM-DD"), institution_dataset_releases[1].end_date
+                )
 
                 self.assert_cleanup(download_folder, extract_folder, transform_folder)
 
@@ -645,20 +659,22 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
     @patch("academic_observatory_workflows.workflows.openalex_telescope.boto3.client")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.get_aws_conn_info")
     @patch("academic_observatory_workflows.workflows.openalex_telescope.Variable.get")
-    def test_write_transfer_manifest(self, mock_variable_get, mock_aws_info, mock_boto3, mock_get_datasets,
-                                     mock_get_releases):
+    def test_write_transfer_manifest(
+        self, mock_variable_get, mock_aws_info, mock_boto3, mock_get_datasets, mock_get_releases
+    ):
         """Test write_transfer_manifest method of the OpenAlex release.
 
         :param mock_variable_get: Mock Airflow Variable get() method
         :param mock_boto3: Mock the boto3 client
         :return: None.
         """
-        mock_get_datasets.return_value = [SimpleNamespace(name="OpenAlex Author Dataset", id=1),
-                                          SimpleNamespace(name="OpenAlex Concept Dataset", id=2),
-                                          SimpleNamespace(name="OpenAlex Institution Dataset", id=3),
-                                          SimpleNamespace(name="OpenAlex Venue Dataset", id=4),
-                                          SimpleNamespace(name="OpenAlex Work Dataset", id=5)
-                                          ]
+        mock_get_datasets.return_value = [
+            SimpleNamespace(name="OpenAlex Author Dataset", id=1),
+            SimpleNamespace(name="OpenAlex Concept Dataset", id=2),
+            SimpleNamespace(name="OpenAlex Institution Dataset", id=3),
+            SimpleNamespace(name="OpenAlex Venue Dataset", id=4),
+            SimpleNamespace(name="OpenAlex Work Dataset", id=5),
+        ]
         mock_variable_get.return_value = "data"
         mock_aws_info.return_value = "key_id", "secret_key"
         # Mock response of get_object on last_modified file, mocking lambda file
@@ -727,23 +743,27 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             # Test successful transfer with prefixes for unchanged, no prefixes for transform
             release.transfer(max_retries=1)
             self.assertDictEqual(
-                {"aws_bucket": OpenAlexTelescope.AWS_BUCKET,
-                 "include_prefixes": ["prefix1", "prefix2"],
-                 "gc_project_id": "project_id",
-                 "gc_bucket": "download-bucket",
-                 "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/unchanged/",
-                 "description": "Transfer OpenAlex data from Airflow telescope to download-bucket"
-                 },
-                mock_transfer.call_args_list[0][1])
+                {
+                    "aws_bucket": OpenAlexTelescope.AWS_BUCKET,
+                    "include_prefixes": ["prefix1", "prefix2"],
+                    "gc_project_id": "project_id",
+                    "gc_bucket": "download-bucket",
+                    "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/unchanged/",
+                    "description": "Transfer OpenAlex data from Airflow telescope to download-bucket",
+                },
+                mock_transfer.call_args_list[0][1],
+            )
             self.assertDictEqual(
-                {"aws_bucket": OpenAlexTelescope.AWS_BUCKET,
-                 "include_prefixes": ["prefix1", "prefix2"],
-                 "gc_project_id": "project_id",
-                 "gc_bucket": "transform-bucket",
-                 "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/",
-                 "description": "Transfer OpenAlex data from Airflow telescope to transform-bucket"
-                 },
-                mock_transfer.call_args_list[1][1])
+                {
+                    "aws_bucket": OpenAlexTelescope.AWS_BUCKET,
+                    "include_prefixes": ["prefix1", "prefix2"],
+                    "gc_project_id": "project_id",
+                    "gc_bucket": "transform-bucket",
+                    "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/",
+                    "description": "Transfer OpenAlex data from Airflow telescope to transform-bucket",
+                },
+                mock_transfer.call_args_list[1][1],
+            )
             mock_transfer.reset_mock()
 
             # Test failed transfer

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -20,8 +20,8 @@ import io
 import json
 import os
 from subprocess import Popen
+from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
-from dateutil import tz
 
 import pendulum
 from airflow.exceptions import AirflowException, AirflowSkipException
@@ -29,6 +29,7 @@ from airflow.models import Connection
 from airflow.utils.state import State
 from botocore.response import StreamingBody
 from click.testing import CliRunner
+from dateutil import tz
 
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.openalex_telescope import (
@@ -257,7 +258,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
             # Add connection
             conn = Connection(
-                conn_id=OpenAlexTelescope.AIRFLOW_CONN_AWS, uri="aws://UWLA41aAhdja:AJLD91saAJSKAL0AjAhkaka@"
+                conn_id=OpenAlexTelescope.AIRFLOW_CONN_AWS, uri='aws://UWLA41aAhdja:AJLD91saAJSKAL0AjAhkaka@'
             )
             env.add_connection(conn)
 
@@ -423,7 +424,6 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
                 # Test create bigquery snapshot
                 ti = env.run_task(telescope.bq_create_snapshot.__name__)
                 self.assertEqual(ti.state, State.SUCCESS)
-
 
                 # Test adding of dataset releases as well as cleanup
                 download_folder, extract_folder, transform_folder = (
@@ -653,7 +653,6 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         :param mock_boto3: Mock the boto3 client
         :return: None.
         """
-        from types import SimpleNamespace
         mock_get_datasets.return_value = [SimpleNamespace(name="OpenAlex Author Dataset", id=1),
                                           SimpleNamespace(name="OpenAlex Concept Dataset", id=2),
                                           SimpleNamespace(name="OpenAlex Institution Dataset", id=3),
@@ -729,20 +728,20 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
             release.transfer(max_retries=1)
             self.assertDictEqual(
                 {"aws_bucket": OpenAlexTelescope.AWS_BUCKET,
-                "include_prefixes": ["prefix1", "prefix2"],
-                "gc_project_id": "project_id",
-                "gc_bucket": "download-bucket",
-                "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/unchanged/",
-                "description": "Transfer OpenAlex data from Airflow telescope to download-bucket"
+                 "include_prefixes": ["prefix1", "prefix2"],
+                 "gc_project_id": "project_id",
+                 "gc_bucket": "download-bucket",
+                 "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/unchanged/",
+                 "description": "Transfer OpenAlex data from Airflow telescope to download-bucket"
                  },
                 mock_transfer.call_args_list[0][1])
             self.assertDictEqual(
                 {"aws_bucket": OpenAlexTelescope.AWS_BUCKET,
-                "include_prefixes": ["prefix1", "prefix2"],
-                "gc_project_id": "project_id",
-                "gc_bucket": "transform-bucket",
-                "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/",
-                "description": "Transfer OpenAlex data from Airflow telescope to transform-bucket"
+                 "include_prefixes": ["prefix1", "prefix2"],
+                 "gc_project_id": "project_id",
+                 "gc_bucket": "transform-bucket",
+                 "gc_bucket_path": "telescopes/dag_id/2022_01_01-2022_02_01/",
+                 "description": "Transfer OpenAlex data from Airflow telescope to transform-bucket"
                  },
                 mock_transfer.call_args_list[1][1])
             mock_transfer.reset_mock()

--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -698,11 +698,20 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         :return: None.
         """
         mock_get_datasets.return_value = [
-            SimpleNamespace(name="OpenAlex Author Dataset", id=1),
-            SimpleNamespace(name="OpenAlex Concept Dataset", id=2),
-            SimpleNamespace(name="OpenAlex Institution Dataset", id=3),
-            SimpleNamespace(name="OpenAlex Venue Dataset", id=4),
-            SimpleNamespace(name="OpenAlex Work Dataset", id=5),
+            SimpleNamespace(name="OpenAlex Dataset", dataset_type=SimpleNamespace(type_id="openalex"), id=1),
+            SimpleNamespace(
+                name="OpenAlex Author Dataset", dataset_type=SimpleNamespace(type_id="openalex_author"), id=2
+            ),
+            SimpleNamespace(
+                name="OpenAlex Concept Dataset", dataset_type=SimpleNamespace(type_id="openalex_concept"), id=3
+            ),
+            SimpleNamespace(
+                name="OpenAlex Institution Dataset", dataset_type=SimpleNamespace(type_id="openalex_institution"), id=4
+            ),
+            SimpleNamespace(
+                name="OpenAlex Venue Dataset", dataset_type=SimpleNamespace(type_id="openalex_venue"), id=5
+            ),
+            SimpleNamespace(name="OpenAlex Work Dataset", dataset_type=SimpleNamespace(type_id="openalex_work"), id=6),
         ]
         mock_variable_get.return_value = "data"
         mock_aws_info.return_value = "key_id", "secret_key"
@@ -720,7 +729,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
         with CliRunner().isolated_filesystem():
             # Test with entries in manifest objects that are after end date of latest release
             mock_get_releases.return_value = [{"end_date": datetime.datetime(2021, 1, 1, tzinfo=tz.UTC)}]
-            release = OpenAlexRelease("dag_id", 1, "dataset_type", start_date, end_date, False, 1)
+            release = OpenAlexRelease("dag_id", 1, OpenAlexTelescope.DAG_ID, start_date, end_date, False, 1)
 
             release.write_transfer_manifest()
             self.assert_file_integrity(
@@ -732,7 +741,7 @@ class TestOpenAlexTelescope(ObservatoryTestCase):
 
             # Test with entries in manifest objects that are before end date of latest release
             mock_get_releases.return_value = [{"end_date": datetime.datetime(2022, 2, 1, tzinfo=tz.UTC)}]
-            release = OpenAlexRelease("dag_id", 1, "dataset_type_id", start_date, end_date, False, 1)
+            release = OpenAlexRelease("dag_id", 1, OpenAlexTelescope.DAG_ID, start_date, end_date, False, 1)
 
             with self.assertRaises(AirflowSkipException):
                 release.write_transfer_manifest()

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -154,7 +154,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
         :return: None
         """
 
-        dag = OrcidTelescope().make_dag()
+        dag = OrcidTelescope(workflow_id=0).make_dag()
         self.assert_dag_structure(
             {
                 "check_dependencies": ["transfer"],
@@ -694,9 +694,9 @@ class TestOrcidTelescope(ObservatoryTestCase):
 
         # Test that all dependencies are specified: no error should be thrown
         mock_bucket_exists.return_value = True
-        OrcidTelescope().check_dependencies()
+        OrcidTelescope(workflow_id=0).check_dependencies()
 
         # Test that dependency is missing, no existing storage bucket
         mock_bucket_exists.return_value = False
         with self.assertRaises(AirflowException):
-            OrcidTelescope().check_dependencies()
+            OrcidTelescope(workflow_id=0).check_dependencies()

--- a/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_orcid_telescope.py
@@ -128,7 +128,7 @@ class TestOrcidTelescope(ObservatoryTestCase):
         self.api.put_table_type(table_type)
 
         dataset_type = DatasetType(
-            type_id="orcid",
+            type_id=OrcidTelescope.DAG_ID,
             name="ds type",
             extra={},
             table_type=TableType(id=1),

--- a/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_unpaywall_telescope.py
@@ -392,7 +392,7 @@ class TestUnpaywallTelescope(ObservatoryTestCase):
         m_makeapi.return_value = self.api
         with self.env.create():
             self.setup_api()
-            dag = UnpaywallTelescope().make_dag()
+            dag = UnpaywallTelescope(workflow_id=0).make_dag()
             self.assert_dag_structure(
                 {
                     "check_dependencies": ["check_releases"],

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -200,6 +200,7 @@ class UnpaywallTelescope(StreamTelescope):
 
     def __init__(
         self,
+        workflow_id: int,
         dag_id: str = DAG_ID,
         start_date: pendulum.DateTime = pendulum.datetime(2021, 7, 2),
         schedule_interval: str = "@daily",
@@ -208,7 +209,6 @@ class UnpaywallTelescope(StreamTelescope):
         merge_partition_field: str = "doi",
         schema_folder: str = default_schema_folder(),
         airflow_vars: List = None,
-        workflow_id: int = None,
         dataset_type_id: str = DatasetTypeId.unpaywall,
     ):
         """Unpaywall Data Feed telescope.

--- a/academic_observatory_workflows/workflows/unpaywall_telescope.py
+++ b/academic_observatory_workflows/workflows/unpaywall_telescope.py
@@ -20,6 +20,7 @@ from typing import List
 import pendulum
 from airflow.models.taskinstance import TaskInstance
 
+from academic_observatory_workflows.api_type_ids import DatasetTypeId
 from academic_observatory_workflows.config import schema_folder as default_schema_folder
 from academic_observatory_workflows.workflows.unpaywall_snapshot_telescope import UnpaywallSnapshotRelease
 from observatory.platform.utils.airflow_utils import (
@@ -129,7 +130,6 @@ class UnpaywallRelease(StreamRelease):
             dst = os.path.join(self.download_folder, "unpaywall.jsonl.gz")
             os.rename(file, dst)
 
-
     @staticmethod
     def get_unpaywall_daily_feeds():
         url = UnpaywallRelease.data_feed_url()
@@ -209,6 +209,7 @@ class UnpaywallTelescope(StreamTelescope):
         schema_folder: str = default_schema_folder(),
         airflow_vars: List = None,
         workflow_id: int = None,
+        dataset_type_id: str = DatasetTypeId.unpaywall,
     ):
         """Unpaywall Data Feed telescope.
 
@@ -245,6 +246,7 @@ class UnpaywallTelescope(StreamTelescope):
             airflow_conns=[UnpaywallTelescope.AIRFLOW_CONNECTION],
             load_bigquery_table_kwargs={"ignore_unknown_values": True},
             workflow_id=workflow_id,
+            dataset_type_id=dataset_type_id,
         )
 
         self.add_setup_task(self.check_dependencies)


### PR DESCRIPTION
Fix to update the records correctly:
* Create a dataset release for each OpenAlex entity.
* Set the end date of each dataset release to the last update date of that entity. This update date is retrieved from the OpenAlex manifest records.
* Use the dataset release end date when deciding which files need to be downloaded from the OpenAlex s3 bucket. 

Use BigQuery snapshots, for each entity:
* Append new records into an ingestion time partitioned table, this is the 'main' table.
* If there are multiple records with the same id, then delete the older ones, this is determined by the partition date of the record.
* Create a BQ snapshot of the 'main' table each run after the table has been updated, each snapshot is stored as a sharded table.