### PR TITLE
Update fieldname "metrics_citations_per_cited_output"

### DIFF
--- a/academic_observatory_workflows/database/mappings/ao-metrics-mappings.json.jinja2
+++ b/academic_observatory_workflows/database/mappings/ao-metrics-mappings.json.jinja2
@@ -122,7 +122,7 @@
       "metrics_outputs_without_citations": {
         "type": "long"
       },
-      "metrics_citations_per_cited_outputs": {
+      "metrics_citations_per_cited_output": {
         "type": "double"
       }
     }


### PR DESCRIPTION
Fixes error in elastic_import_observatory DAG:
`mapper [metrics_citations_per_cited_output] cannot be changed from type [long] to [float]'}`

Similar to a previous issue, the typing of the field 'metrics_citations_per_cited_output' was interpolated from the data instead of from the mapping file, because this field was not defined in the mapping file.

There was a 'metrics_citations_per_cited_outputs' field in ao-metrics-mappings.json.jinja2, which probably should have been 'metrics_citations_per_cited_output' instead.