### PR TITLE
INF-521 DOI Workflow: Remove DOI  table being output to coki-dashboards

### DIFF
--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -758,7 +758,7 @@ class DoiWorkflow(Workflow):
         """
 
         results = []
-        table_ids = [agg.table_id for agg in DoiWorkflow.AGGREGATIONS] + ["doi"]
+        table_ids = [agg.table_id for agg in DoiWorkflow.AGGREGATIONS]
         for table_id in table_ids:
             source_table_id = f"{self.output_project_id}.{self.observatory_dataset_id}.{bigquery_sharded_table_id(table_id, release.release_date)}"
             destination_table_id = f"{self.output_project_id}.{self.dashboards_dataset_id}.{table_id}"

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -580,7 +580,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
                 # Test copy to dashboards
                 ti = env.run_task("copy_to_dashboards")
                 self.assertEqual(expected_state, ti.state)
-                table_ids = [agg.table_id for agg in DoiWorkflow.AGGREGATIONS] + ["doi"]
+                table_ids = [agg.table_id for agg in DoiWorkflow.AGGREGATIONS]
                 for table_id in table_ids:
                     self.assert_table_integrity(f"{self.project_id}.{dashboards_dataset_id}.{table_id}")
 


### PR DESCRIPTION
Removed DOI from the list of tables to be copied over to the COKI Dashboards. 