### PR TITLE
INF-557: Removed authors from the list of aggregations

### DIFF
--- a/academic_observatory_workflows/dags/doi_workflow.py
+++ b/academic_observatory_workflows/dags/doi_workflow.py
@@ -33,7 +33,6 @@ Each release is saved to the following BigQuery tables:
 
 Every week the following tables are overwritten for visualisation in the Data Studio dashboards:
     <project_id>.coki_dashboards.country
-    <project_id>.coki_dashboards.doi
     <project_id>.coki_dashboards.funder
     <project_id>.coki_dashboards.group
     <project_id>.coki_dashboards.institution

--- a/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
+++ b/academic_observatory_workflows/workflows/tests/test_doi_workflow.py
@@ -295,10 +295,8 @@ class TestDoiWorkflow(ObservatoryTestCase):
                 "create_orcid": ["create_doi"],
                 "create_open_citations": ["create_doi"],
                 "create_unpaywall": ["create_doi"],
-                "create_openalex" : ["create_doi"],
-                "create_doi": [
-                    "create_book",
-                ],
+                "create_openalex": ["create_doi"],
+                "create_doi": ["create_book"],
                 "create_book": [
                     "create_country",
                     "create_funder",
@@ -325,7 +323,6 @@ class TestDoiWorkflow(ObservatoryTestCase):
                     "export_funder",
                     "export_group",
                     "export_institution",
-                    "export_author",
                     "export_journal",
                     "export_publisher",
                     "export_region",
@@ -335,7 +332,6 @@ class TestDoiWorkflow(ObservatoryTestCase):
                 "export_funder": ["add_new_dataset_releases"],
                 "export_group": ["add_new_dataset_releases"],
                 "export_institution": ["add_new_dataset_releases"],
-                "export_author": ["add_new_dataset_releases"],
                 "export_journal": ["add_new_dataset_releases"],
                 "export_publisher": ["add_new_dataset_releases"],
                 "export_region": ["add_new_dataset_releases"],
@@ -676,7 +672,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
                 "region",
                 "subregion",
                 "total_outputs",
-                "repositories"
+                "repositories",
             ]:
                 self.assertEqual(expected_item[key], actual_item[key])
 
@@ -719,7 +715,7 @@ class TestDoiWorkflow(ObservatoryTestCase):
         eps = 0.01  # Allow slight rounding errors between Python and SQL
 
         for key in sub_fields:
-            if(type(expected[field][key]) == float):
+            if type(expected[field][key]) == float:
                 self.assertTrue(abs(expected[field][key] - actual[field][key]) <= eps)
             else:
                 self.assertEqual(expected[field][key], actual[field][key])


### PR DESCRIPTION
To save space on Elastisearch, it is required that the authors aggregation table be removed from the list of aggregations being created by the DOI Workflow.

Created a seperate function in the DOI Workflow to remove one or a number of aggregations from a list of aggregation objects. The original list of aggregations are copied and the function returns a list of aggregations with the desired aggregations are removed. Aggregations to remove are matched on the "table_id".

The export for Elastic now depends on a list of aggregations with the "author" aggregation removed. No other parts of the workflow is affected. 

Unit test for the DOI Workflow have been modified for the removal of the "export_author" task.