### PR TITLE
DOI Workflow: add genealogical institutions

### DIFF
--- a/academic_observatory_workflows/database/sql/create_doi.sql.jinja2
+++ b/academic_observatory_workflows/database/sql/create_doi.sql.jinja2
@@ -15,19 +15,19 @@
 # Author: Richard Hosking, James Diprose #}
 
 -- Create a table of DOI to ROR affiliations, including direct affiliations (author_rors) and indirect affiliations through the ROR parent relationships (hierarchy_rors)
-WITH coki_ror_temp as (
+WITH coki_affiliations_temp as (
   SELECT
-  coki_ror.doi,
-  author_rors,
-  ARRAY(SELECT DISTINCT * FROM coki_ror.hierarchy_rors) as hierarchy_rors
+  coki_affiliations.doi,
+  author_institutions,
+  ARRAY(SELECT DISTINCT * FROM coki_affiliations.genealogical_institutions) as genealogical_institutions
   FROM
     (SELECT
       openalex.doi,
-      ARRAY_AGG(DISTINCT ror_hierarchy.child_id IGNORE NULLS) as author_rors,
-      ARRAY_CONCAT_AGG(ror_hierarchy.ror_ids) as hierarchy_rors
+      ARRAY_AGG(DISTINCT ror_hierarchy.child_id IGNORE NULLS) as author_institutions,
+      ARRAY_CONCAT_AGG(ror_hierarchy.ror_ids) as genealogical_institutions
     FROM `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.openalex{{ release_date.strftime('%Y%m%d') }}` as openalex, UNNEST(IF(openalex.authorships is not null, openalex.authorships, [])) AS authors, UNNEST(IF(authors.institutions is not null, authors.institutions, [])) as institution
     LEFT JOIN `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.ror_hierarchy{{ release_date.strftime('%Y%m%d') }}` as ror_hierarchy ON ror_hierarchy.child_id = institution.ror
-    GROUP BY openalex.doi) as coki_ror
+    GROUP BY openalex.doi) as coki_affiliations
 ),
 
 
@@ -51,7 +51,7 @@ SELECT
     (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.mag{{ release_date.strftime('%Y%m%d') }}` as mag WHERE mag.doi = UPPER(TRIM(ref.doi))) as mag,
     (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.open_citations{{ release_date.strftime('%Y%m%d') }}` as oa WHERE oa.doi = UPPER(TRIM(ref.doi))) as open_citations,
     (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.crossref_events{{ release_date.strftime('%Y%m%d') }}` as events WHERE events.doi = UPPER(TRIM(ref.doi))) as events,
-    (SELECT as STRUCT * from coki_ror_temp as coki_rors WHERE coki_rors.doi = UPPER(TRIM(ref.doi))) as coki_rors,
+    (SELECT as STRUCT * from coki_affiliations_temp as coki_affiliations WHERE coki_affiliations.doi = UPPER(TRIM(ref.doi))) as coki_affiliations,
   FROM `{{ crossref_metadata.project_id }}.{{ crossref_metadata.dataset_id }}.crossref_metadata{{ crossref_metadata.release_date.strftime('%Y%m%d') }}` as ref
   WHERE ARRAY_LENGTH(issued.date_parts) > 0)
 ),
@@ -60,7 +60,6 @@ SELECT
 affiliations_temp_table as (
 SELECT
   extras.doi as doi,
-  coki_rors,
   institutions,
 
   {#
@@ -223,7 +222,7 @@ SELECT
 
    Lastly, Fundref and ORCID are also LEFT JOINed in order to drive the Funder and Author relationships
   #}
-  FROM dois_temp_table as dois, UNNEST(coki_rors.hierarchy_rors) as ror_id
+  FROM dois_temp_table as dois, UNNEST(coki_affiliations.genealogical_institutions) as ror_id
   LEFT JOIN `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.ror{{ release_date.strftime('%Y%m%d') }}` as institution on ror_id = institution.id
   LEFT JOIN (SELECT ror, ARRAY_AGG(STRUCT(group_id, group_name, country_code)) as groupings FROM `{{ settings.project_id }}.{{ settings.dataset_id }}.groupings` CROSS JOIN UNNEST(rors) as ror GROUP BY ror) as ror_groups on institution.id = ror_groups.ror
   GROUP BY doi) as base on extras.doi = base.doi
@@ -237,7 +236,7 @@ Brings together the two temporary tables above.
 - affiliations is the derived data that neatly organises all the relationships a doi has to authors, their institutions, countries and regions of those institutions, publisher, journal, funders
 #}
 SELECT
-  dois.* EXCEPT (coki_rors, unpaywall),
+  dois.* EXCEPT (coki_affiliations, unpaywall),
   -- Put the unpaywall struct back how it used to be for backwards compatibility
   (SELECT as STRUCT
     dois.unpaywall.* EXCEPT(repositories, oa_color, oa_license, oa_coki),
@@ -250,7 +249,10 @@ SELECT
     dois.unpaywall.oa_license as oa_license,
     dois.unpaywall.oa_coki as oa_coki,
     dois.unpaywall.repositories as repositories,
-    coki_rors as rors
+    STRUCT(
+       dois.coki_affiliations.author_institutions as author_institutions,
+       dois.coki_affiliations.genealogical_institutions as genealogical_institutions
+    ) as affiliation
   ) as coki,
   affiliations
 FROM dois_temp_table as dois

--- a/academic_observatory_workflows/database/sql/create_doi.sql.jinja2
+++ b/academic_observatory_workflows/database/sql/create_doi.sql.jinja2
@@ -14,12 +14,28 @@
 
 # Author: Richard Hosking, James Diprose #}
 
+-- Create a table of DOI to ROR affiliations, including direct affiliations (author_rors) and indirect affiliations through the ROR parent relationships (hierarchy_rors)
+WITH coki_ror_temp as (
+  SELECT
+  coki_ror.doi,
+  author_rors,
+  ARRAY(SELECT DISTINCT * FROM coki_ror.hierarchy_rors) as hierarchy_rors
+  FROM
+    (SELECT
+      openalex.doi,
+      ARRAY_AGG(DISTINCT ror_hierarchy.child_id IGNORE NULLS) as author_rors,
+      ARRAY_CONCAT_AGG(ror_hierarchy.ror_ids) as hierarchy_rors
+    FROM `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.openalex{{ release_date.strftime('%Y%m%d') }}` as openalex, UNNEST(IF(openalex.authorships is not null, openalex.authorships, [])) AS authors, UNNEST(IF(authors.institutions is not null, authors.institutions, [])) as institution
+    LEFT JOIN `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.ror_hierarchy{{ release_date.strftime('%Y%m%d') }}` as ror_hierarchy ON ror_hierarchy.child_id = institution.ror
+    GROUP BY openalex.doi) as coki_ror
+),
+
+
 {# This query, using crossref metadata as the reference, links together all the other tables that expose objects with doi as the primairy key #}
-WITH dois_temp_table as (
+dois_temp_table as (
 SELECT
   *,
-  (SELECT ARRAY(SELECT DISTINCT institution.ror FROM UNNEST(IF(openalex.authorships is not null, openalex.authorships, [])) AS authors, UNNEST(IF(authors.institutions is not null, authors.institutions, [])) as institution)) as openalex_rors
-FROM
+ FROM
   (SELECT
     {# This SQL block links unpaywall, mag, open citations and crossref events to the DOI and the metadata found in the crossref metadata dataset #}
     UPPER(TRIM(ref.doi)) as doi,
@@ -34,7 +50,8 @@ FROM
     (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.openalex{{ release_date.strftime('%Y%m%d') }}` as openalex WHERE openalex.doi = UPPER(TRIM(ref.doi))) as openalex,
     (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.mag{{ release_date.strftime('%Y%m%d') }}` as mag WHERE mag.doi = UPPER(TRIM(ref.doi))) as mag,
     (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.open_citations{{ release_date.strftime('%Y%m%d') }}` as oa WHERE oa.doi = UPPER(TRIM(ref.doi))) as open_citations,
-    (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.crossref_events{{ release_date.strftime('%Y%m%d') }}` as events WHERE events.doi = UPPER(TRIM(ref.doi))) as events
+    (SELECT as STRUCT * from `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.crossref_events{{ release_date.strftime('%Y%m%d') }}` as events WHERE events.doi = UPPER(TRIM(ref.doi))) as events,
+    (SELECT as STRUCT * from coki_ror_temp as coki_rors WHERE coki_rors.doi = UPPER(TRIM(ref.doi))) as coki_rors,
   FROM `{{ crossref_metadata.project_id }}.{{ crossref_metadata.dataset_id }}.crossref_metadata{{ crossref_metadata.release_date.strftime('%Y%m%d') }}` as ref
   WHERE ARRAY_LENGTH(issued.date_parts) > 0)
 ),
@@ -43,7 +60,7 @@ FROM
 affiliations_temp_table as (
 SELECT
   extras.doi as doi,
-
+  coki_rors,
   institutions,
 
   {#
@@ -206,7 +223,7 @@ SELECT
 
    Lastly, Fundref and ORCID are also LEFT JOINed in order to drive the Funder and Author relationships
   #}
-  FROM dois_temp_table as dois, UNNEST(openalex_rors) as ror_id
+  FROM dois_temp_table as dois, UNNEST(coki_rors.hierarchy_rors) as ror_id
   LEFT JOIN `{{ observatory_intermediate.project_id }}.{{ observatory_intermediate.dataset_id }}.ror{{ release_date.strftime('%Y%m%d') }}` as institution on ror_id = institution.id
   LEFT JOIN (SELECT ror, ARRAY_AGG(STRUCT(group_id, group_name, country_code)) as groupings FROM `{{ settings.project_id }}.{{ settings.dataset_id }}.groupings` CROSS JOIN UNNEST(rors) as ror GROUP BY ror) as ror_groups on institution.id = ror_groups.ror
   GROUP BY doi) as base on extras.doi = base.doi
@@ -220,7 +237,7 @@ Brings together the two temporary tables above.
 - affiliations is the derived data that neatly organises all the relationships a doi has to authors, their institutions, countries and regions of those institutions, publisher, journal, funders
 #}
 SELECT
-  dois.* EXCEPT (openalex_rors, unpaywall),
+  dois.* EXCEPT (coki_rors, unpaywall),
   -- Put the unpaywall struct back how it used to be for backwards compatibility
   (SELECT as STRUCT
     dois.unpaywall.* EXCEPT(repositories, oa_color, oa_license, oa_coki),
@@ -232,7 +249,8 @@ SELECT
     dois.unpaywall.oa_color as oa_color,
     dois.unpaywall.oa_license as oa_license,
     dois.unpaywall.oa_coki as oa_coki,
-    dois.unpaywall.repositories as repositories
+    dois.unpaywall.repositories as repositories,
+    coki_rors as rors
   ) as coki,
   affiliations
 FROM dois_temp_table as dois

--- a/academic_observatory_workflows/fixtures/doi/create_repo_institution_to_ror_table.yaml
+++ b/academic_observatory_workflows/fixtures/doi/create_repo_institution_to_ror_table.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3791a4f41fc114f4d49aca110106e98660a07b26dc115cfdd0f628ae5a04fc5
+size 179187

--- a/academic_observatory_workflows/fixtures/doi/ror.jsonl
+++ b/academic_observatory_workflows/fixtures/doi/ror.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adee538c35cd5e1c2b326b881241c25e50c8305871a258cc36b269e184f507fb
-size 4590
+oid sha256:f400a56795a058a08e32732f7b4e1bfdca19d6c2ead396cfb7a1febd26afdc01
+size 334654

--- a/academic_observatory_workflows/fixtures/doi/ror_subset.py
+++ b/academic_observatory_workflows/fixtures/doi/ror_subset.py
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e3902cb5ddd57da420d6aa429980a4d55c811f7e7ca0b28fd178f71b0a35ad3
+size 1421

--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -763,17 +763,17 @@ class DoiWorkflow(Workflow):
         """
 
         # Fetch latest ROR table
-        ror_table_id = "ror"
+        ror_table_name = "ror"
         ror_release_date = select_table_shard_dates(
             project_id=self.input_project_id,
             dataset_id=self.ror_dataset_id,
-            table_id=ror_table_id,
+            table_id=ror_table_name,
             end_date=release.release_date,
         )[0]
-        table_id = bigquery_sharded_table_id(ror_table_id, ror_release_date)
-        ror = run_bigquery_query(
-            f"SELECT * FROM {table_id}"
+        table_id = bigquery_sharded_table_id(
+            f"{self.input_project_id}.{self.ror_dataset_id}.{ror_table_name}", ror_release_date
         )
+        ror = [dict(row) for row in run_bigquery_query(f"SELECT * FROM {table_id}")]
 
         # Create ROR hierarchy table
         index = ror_to_ror_hierarchy_index(ror)


### PR DESCRIPTION
This PR adjusts the DOI workflow to produce aggregate statistics based on direct institutions (author institutions) and ancestral institutions (the ancestral institutions of the direct author institutions). This should produce institutional statistics more in line with MAG. 
* Adds a task to the DOI workflow which creates an index table that maps ROR ids to all ancestor ROR ids using the ROR parent child relationships.
* Modify DOI table coki struct to list author institution ROR ids and genealogical institutions ROR ids (author institutions + their ancestors).
* Modify create_doi.sql.jinja2 to produce aggregations based on genealogical institutions rather than author institutions.