### PR TITLE
INF-484: Added validate logos set to workflow

### DIFF
--- a/academic_observatory_workflows/image.py
+++ b/academic_observatory_workflows/image.py
@@ -1,0 +1,95 @@
+# Copyright 2022 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Alex Massen-Hane
+
+""" Image verification and integrity checking functions """
+
+import os
+import logging
+from airflow import AirflowException
+
+import PIL
+import cairosvg
+
+def check_image_integrity(image_path: str):
+
+    """ Check if images are in an accepted format, if they exist and if they are corrupt. 
+    Check is performed by verifying and rotating/transposing. 
+
+    PIL can take multiple different file formats, just not SVGs. 
+    SVGs are converted to a PNG as required.
+
+    :param image_path: Path to the image to check.
+    :param fmt: File format of the image.
+    :return valid_file: True if image is valid, otherwise false. 
+
+    """
+
+    # Parameter needed for PIL library to allow large images.
+    PIL.Image.MAX_IMAGE_PIXELS = 933120000
+
+    image_type = image_path.split('.')[-1]
+
+    accepted_image_types = ['svg', 'jpg', 'jpeg', 'png', 'webp'] 
+    if image_type in accepted_image_types:
+        if image_type == 'svg':
+            # Convert SVG to PNG
+            cairosvg.svg2png(url=image_path, write_to='output.png')
+            valid_file = pil_check("output.png")
+            os.remove("output.png")
+            if os.path.exists("output.png"):
+                raise AirflowException("Output.png still exists after image check.")
+        else:
+            valid_file = pil_check(image_path)   
+    else:
+        valid_file = False
+        raise AirflowException(f'Image is neither a {accepted_image_types} : {image_path}')
+
+    return valid_file
+
+def pil_check(image_path: str):
+
+    """Verifies integrity of images using PIL (Pillow) library, by verifying and 
+    doing a basic transpose and flip.
+
+    :param image_path: Path to the image, e.g. /path/to/file/picture.png
+    :return valid_file: Return true if image is okay, otherwise false.
+    """
+
+    try:
+        valid_file = True
+        try: 
+            # Open and verify image.
+            img = PIL.Image.open(image_path)
+            img.verify()
+            img.close()
+        except:
+            logging.error('Unable to do verification on image: ', image_path)
+            valid_file = False
+        
+        try: 
+            # Open and do a transpose and flip.
+            img = PIL.Image.open(image_path)
+            img.transpose(PIL.Image.Transpose.FLIP_LEFT_RIGHT)
+            img.close()
+        except:
+            logging.error('Unable to do transpose on image: ', image_path)
+            valid_file = False  
+
+    except:
+        valid_file = False
+        logging.error("Unable to check the integrity of picture: " + image_path)
+
+    return valid_file

--- a/academic_observatory_workflows/tests/test_image.py
+++ b/academic_observatory_workflows/tests/test_image.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Curtin University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author: Alex Massen-Hane
+
+import os
+import unittest
+import PIL
+import cairosvg
+from numpy import asarray
+
+from academic_observatory_workflows.image import check_image_integrity
+
+
+class TestImageVerification(unittest.TestCase):
+
+    def test_check_image_ingetrity(self):
+        """Test image verification and conversion."""
+
+        try: 
+            # Create mock SVG for testing
+            svg_mock = """
+                        <svg xmlns="http://www.w3.org/2000/svg" width="4" 
+                            height="4" viewBox="0 0 4 4" fill="none" 
+                            stroke="#043" stroke-width="1" stroke-linecap="round" 
+                            stroke-linejoin="round">
+                            <line x1="0" y1="0" x2="4" y2="4"/>
+                        </svg>
+                    """ 
+            
+            # Convert mock SVG to PNG 
+            cairosvg.svg2png(bytestring=svg_mock,write_to='output.png')
+
+            # Verify conversion
+            img = PIL.Image.open('output.png')
+            expected_image_array = [ [ [0, 68, 51, 234], [0, 68, 52,  64], [0,  0, 0,    0], [0,  0,  0,   0] ],
+                                     [ [0, 68, 51,  60], [0, 68, 51, 233], [0, 70, 50,  66], [0,  0,  0,   0] ],
+                                     [ [0,  0,  0,   0], [0, 68, 51,  60], [0, 60, 51, 233], [0, 70, 50,  66] ],
+                                     [ [0,  0,  0,   0], [0,  0,  0,   0], [0, 68, 52,  64], [0, 68, 51, 234] ] ]
+            self.assertEquals(asarray(expected_image_array).all(), asarray(img).all())
+
+            # Check image integrity (mock is known to be good)
+            success = check_image_integrity(image_path='output.png')
+            self.assertTrue(success)
+
+        finally:
+            # Delete file created by test.
+            try:
+                os.remove('output.png')
+            except:
+                raise Exception('Unable to delete output.png from test.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ boto3>=1.15.0,<2
 pyarrow>=6,<7
 nltk==3.*
 Deprecated>1,<2
+
+image==1.5.33
+CairoSVG==2.5.2


### PR DESCRIPTION
Added validate_logos step in the download_logos task of the oa_web_workflow to ensure that logos exist and are not corrupt.

The validate_logo function initially checks if they are in SVG, JPG, JPEG, PNG or WebP format and then uses the PIL library to verify the image and do a simple rotation and flip. If the image is corrupt, these steps will fail and raise an Airflow exception. 