### PR TITLE
Updated regex pattern match

### DIFF
--- a/academic_observatory_workflows/workflows/ror_telescope.py
+++ b/academic_observatory_workflows/workflows/ror_telescope.py
@@ -52,7 +52,7 @@ class RorRelease(SnapshotRelease):
         """
 
         download_files_regex = f"{dag_id}.zip"
-        extract_files_regex = r"^(v\d+.\d+-)?\d{4}-\d{2}-\d{2}-ror-data.json$"
+        extract_files_regex = r"^(v\d+[.\d+]+-)?\d{4}-\d{2}-\d{2}-ror-data.json$"
         transform_files_regex = f"{dag_id}.jsonl.gz"
 
         super().__init__(dag_id, release_date, download_files_regex, extract_files_regex, transform_files_regex)


### PR DESCRIPTION
This PR alters the ROR extract_files regex pattern match. 
The reason being, a recent update (by ROR) changed the version number to 1.17.1. The old regex did not pick this up because it is not able to match on version numbers outside of the format [major].[minor]. The updated regex looks for any number of sub-versions. (e.g. 1.17.1.2.3.4.5)