### PR TITLE
INF-588: HTTP request updates

### DIFF
--- a/academic_observatory_workflows/fixtures/crossref_events/crossref_events1.yaml
+++ b/academic_observatory_workflows/fixtures/crossref_events/crossref_events1.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11b652e14c875ebd521df38a23ee23d4ff4996b6ca56194b0be948436882ce8c
-size 79780
+oid sha256:b638d7c72b838acb2e3d9a0c7e58a3c4ab2dcb25eb08c1711d795fea230a06cc
+size 79748

--- a/academic_observatory_workflows/fixtures/crossref_events/crossref_events2.yaml
+++ b/academic_observatory_workflows/fixtures/crossref_events/crossref_events2.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8add4229c0d2808b0ffb9374d22d845a8ab99ce17d0e6a5690c5c8310fe08a01
-size 107649
+oid sha256:a8924c2d902a3a8d8cbf7d5d420711c659c44c19b0de4e6962e1a3f7ed944131
+size 107565

--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -51,7 +51,7 @@ from observatory.platform.utils.jinja2_utils import (
     make_sql_jinja2_filename,
     render_template,
 )
-from observatory.platform.utils.url_utils import retry_session
+from observatory.platform.utils.url_utils import retry_get_url
 from observatory.platform.utils.workflow_utils import make_release_date
 from observatory.platform.workflows.workflow import Workflow
 
@@ -307,8 +307,8 @@ def fetch_ror_affiliations(repository_institution: str, num_retries: int = 3) ->
     print(f"fetch_ror_affiliations: {repository_institution}")
     rors = []
     try:
-        response = retry_session(num_retries=num_retries).get(
-            "https://api.ror.org/organizations", params={"affiliation": repository_institution}
+        response = retry_get_url(
+            "https://api.ror.org/organizations", num_retries=num_retries, params={"affiliation": repository_institution}
         )
         items = response.json()["items"]
         for item in items:

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -18,6 +18,7 @@ import json
 import os
 from datetime import datetime
 from unittest.mock import patch
+import requests
 
 import httpretty
 import pendulum
@@ -291,7 +292,7 @@ class TestCrossrefMetadataTelescope(ObservatoryTestCase):
         release = self.release
         with httpretty.enabled():
             httpretty.register_uri(httpretty.GET, release.url, body="", status=400)
-            with self.assertRaises(ConnectionError):
+            with self.assertRaises(requests.exceptions.HTTPError):
                 release.download()
 
     @patch("academic_observatory_workflows.workflows.crossref_metadata_telescope.subprocess.Popen")

--- a/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_ror_telescope.py
@@ -17,6 +17,7 @@
 import json
 import os
 from unittest.mock import patch
+import requests
 
 import httpretty
 import jsonlines
@@ -456,5 +457,5 @@ class TestRorTelescope(ObservatoryTestCase):
         # Test list records with a response code that is not 200
         with httpretty.enabled():
             httpretty.register_uri(httpretty.GET, RorTelescope.ROR_DATASET_URL, status=400)
-            with self.assertRaises(AirflowException):
+            with self.assertRaises(requests.exceptions.HTTPError):
                 list_ror_records(start_date, end_date)


### PR DESCRIPTION
Blocked by [observatory-platform-597](https://github.com/The-Academic-Observatory/observatory-platform/pull/597)

This PR utilises the new retry_get_url() function. It also changes the crossref events header to use agent@observatory.academy, rather than Aniek's email.