### PR TITLE
Fix/doi ror affiliation matcher errors

### DIFF
--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -333,7 +333,7 @@ def fetch_ror_affiliations(repository_institution: str, num_retries: int = 3) ->
             if item["chosen"]:
                 org = item["organization"]
                 rors.append({"id": org["id"], "name": org["name"]})
-    except requests.exceptions.RetryError as e:
+    except requests.exceptions.HTTPError as e:
         logging.error(f"requests.exceptions.RetryError fetch_ror_affiliations error fetching: {e}")
 
     return {"repository_institution": repository_institution, "rors": rors}

--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -334,7 +334,9 @@ def fetch_ror_affiliations(repository_institution: str, num_retries: int = 3) ->
                 org = item["organization"]
                 rors.append({"id": org["id"], "name": org["name"]})
     except requests.exceptions.HTTPError as e:
-        logging.error(f"requests.exceptions.RetryError fetch_ror_affiliations error fetching: {e}")
+        # If the repository_institution string causes a 500 error with the ROR affiliation matcher
+        # Then catch the error and continue as if no ROR ids were matched for this entry.
+        logging.error(f"requests.exceptions.HTTPError fetch_ror_affiliations error fetching: {e}")
 
     return {"repository_institution": repository_institution, "rors": rors}
 

--- a/academic_observatory_workflows/workflows/doi_workflow.py
+++ b/academic_observatory_workflows/workflows/doi_workflow.py
@@ -336,7 +336,10 @@ def fetch_ror_affiliations(repository_institution: str, num_retries: int = 3) ->
     except requests.exceptions.HTTPError as e:
         # If the repository_institution string causes a 500 error with the ROR affiliation matcher
         # Then catch the error and continue as if no ROR ids were matched for this entry.
+        # Otherwise, re-raise error as something else is likely wrong
         logging.error(f"requests.exceptions.HTTPError fetch_ror_affiliations error fetching: {e}")
+        if e.response.status_code != 500:
+            raise e
 
     return {"repository_institution": repository_institution, "rors": rors}
 


### PR DESCRIPTION
Fixing an issue where some affiliation strings will cause the ROR affiliation matcher to throw an HTTP 500 error. Catch the HTTP 500 errors and continue as if no ROR ids were matched for this entry, otherwise, re-raise the error as something else is likely wrong.