### PR TITLE
Fix Crossref Metadata release date

### DIFF
--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -242,7 +242,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         self.max_processes = max_processes
 
         self.add_setup_task(self.check_dependencies)
-        self.add_setup_task(self.list_releases)
+        self.add_setup_task(self.check_release_exists)
         self.add_task(self.download)
         self.add_task(self.upload_downloaded)
         self.add_task(self.extract)

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -242,7 +242,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         self.max_processes = max_processes
 
         self.add_setup_task(self.check_dependencies)
-        self.add_setup_task(self.check_release_exists)
+        self.add_setup_task(self.list_releases)
         self.add_task(self.download)
         self.add_task(self.upload_downloaded)
         self.add_task(self.extract)
@@ -262,7 +262,8 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         :return: a list of CrossrefMetadataRelease instances.
         """
 
-        release_date = kwargs["execution_date"]
+        # The release date is always the end of the execution_date month
+        release_date = kwargs["execution_date"].end_of("month")
         return [CrossrefMetadataRelease(self.dag_id, release_date)]
 
     def check_release_exists(self, **kwargs):
@@ -273,6 +274,7 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         for a list of the keyword arguments that are passed to this argument.
         :return: None.
         """
+
         # List all available releases
         logging.info(f"Listing available releases since start date ({self.start_date}):")
         for dt in pendulum.period(pendulum.instance(self.start_date), pendulum.today("UTC")).range("years"):

--- a/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_metadata_telescope.py
@@ -275,7 +275,8 @@ class CrossrefMetadataTelescope(SnapshotTelescope):
         :return: None.
         """
 
-        # List all available releases
+        # List all available releases for logging and debugging purposes
+        # These values are not used to actually check if the release is available
         logging.info(f"Listing available releases since start date ({self.start_date}):")
         for dt in pendulum.period(pendulum.instance(self.start_date), pendulum.today("UTC")).range("years"):
             response = requests.get(f"https://api.crossref.org/snapshots/monthly/{dt.year}")

--- a/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_crossref_metadata_telescope.py
@@ -27,12 +27,6 @@ from airflow.models import Connection
 from airflow.utils.state import State
 from click.testing import CliRunner
 from natsort import natsorted
-from observatory.api.client.model.dataset import Dataset
-from observatory.api.client.model.dataset_type import DatasetType
-from observatory.api.client.model.organisation import Organisation
-from observatory.api.client.model.table_type import TableType
-from observatory.api.client.model.workflow import Workflow
-from observatory.api.client.model.workflow_type import WorkflowType
 
 from academic_observatory_workflows.config import test_fixtures_folder
 from academic_observatory_workflows.workflows.crossref_metadata_telescope import (
@@ -43,6 +37,12 @@ from academic_observatory_workflows.workflows.crossref_metadata_telescope import
 )
 from observatory.api.client import ApiClient, Configuration
 from observatory.api.client.api.observatory_api import ObservatoryApi  # noqa: E501
+from observatory.api.client.model.dataset import Dataset
+from observatory.api.client.model.dataset_type import DatasetType
+from observatory.api.client.model.organisation import Organisation
+from observatory.api.client.model.table_type import TableType
+from observatory.api.client.model.workflow import Workflow
+from observatory.api.client.model.workflow_type import WorkflowType
 from observatory.api.testing import ObservatoryApiEnvironment
 from observatory.platform.utils.airflow_utils import AirflowConns
 from observatory.platform.utils.file_utils import load_jsonl


### PR DESCRIPTION
Fix Crossref Metadata release date, the day of the month should be the last day of the month: e.g. `crossref_metadata20220907` changes to `crossref_metadata20220930`. 