### PR TITLE
Fix write disposition

### DIFF
--- a/academic_observatory_workflows/workflows/crossref_events_telescope.py
+++ b/academic_observatory_workflows/workflows/crossref_events_telescope.py
@@ -514,7 +514,6 @@ class CrossrefEventsTelescope(Workflow):
             table_id=release.bq_main_table_id,
             schema_file_path=self.schema_file_path,
             source_format=SourceFormat.NEWLINE_DELIMITED_JSON,
-            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
             ignore_unknown_values=True,
         )
         set_task_state(success, self.bq_load_main_table.__name__, release)

--- a/academic_observatory_workflows/workflows/open_citations_telescope.py
+++ b/academic_observatory_workflows/workflows/open_citations_telescope.py
@@ -264,7 +264,6 @@ class OpenCitationsTelescope(Workflow):
                 csv_quote_character='"',
                 csv_skip_leading_rows=1,
                 csv_allow_quoted_newlines=True,
-                write_disposition=bigquery.WriteDisposition.WRITE_APPEND,
                 ignore_unknown_values=True,
             )
             set_task_state(success, self.bq_load.__name__, release)


### PR DESCRIPTION
OpenCitations shouldn't be using append and the main table of Crossref Events can use the default write empy.