### PR TITLE
Fix/Add s3:// prefix to OpenAlex AWS blob URL if not present

### DIFF
--- a/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_openalex_telescope.py
@@ -142,6 +142,10 @@ class TestOpenAlexUtils(ObservatoryTestCase):
         self.assertEqual(pendulum.datetime(2022, 12, 20), entry.updated_date)
         self.assertEqual("part_000.gz", entry.file_name)
 
+        # Assert that manifest entry without a s3:// url prefix is still valid.
+        manifest_entry_no_s3 = ManifestEntry("openalex/data/works/updated_date=2022-12-20/part_000.gz", Meta(7073, 4))
+        self.assertEqual(manifest_entry_no_s3.url, "s3://openalex/data/works/updated_date=2022-12-20/part_000.gz")
+
         # object_key
         manifest_entry = ManifestEntry("s3://openalex/data/works/updated_date=2022-12-20/part_000.gz", Meta(7073, 4))
         self.assertEqual("data/works/updated_date=2022-12-20/part_000.gz", manifest_entry.object_key)
@@ -373,50 +377,34 @@ class TestOpenAlexUtils(ObservatoryTestCase):
         """Test the transform_object function."""
 
         # Null
-        obj = {
-            "corresponding_institution_ids": None
-        }
+        obj = {"corresponding_institution_ids": None}
         transform_object(obj)
         self.assertDictEqual(
-            {
-                "corresponding_institution_ids": []
-            },
+            {"corresponding_institution_ids": []},
             obj,
         )
 
         # Null
-        obj = {
-            "corresponding_author_ids": None
-        }
+        obj = {"corresponding_author_ids": None}
         transform_object(obj)
         self.assertDictEqual(
-            {
-                "corresponding_author_ids": []
-            },
+            {"corresponding_author_ids": []},
             obj,
         )
 
         # Null in array
-        obj = {
-            "corresponding_institution_ids": [None]
-        }
+        obj = {"corresponding_institution_ids": [None]}
         transform_object(obj)
         self.assertDictEqual(
-            {
-                "corresponding_institution_ids": []
-            },
+            {"corresponding_institution_ids": []},
             obj,
         )
 
         # Null in array
-        obj = {
-            "corresponding_author_ids": [None]
-        }
+        obj = {"corresponding_author_ids": [None]}
         transform_object(obj)
         self.assertDictEqual(
-            {
-                "corresponding_author_ids": []
-            },
+            {"corresponding_author_ids": []},
             obj,
         )
 


### PR DESCRIPTION
Sometimes URLs for AWS blobs do not have the s3:// prefix, but it is required in later parts of the workflow for transferring files from the AWS bucket to GCS.

This PR adds the prefix in the ManifestEntry class if the URL does not start with it.
Assert is added in the ManifestEntry test to make sure that it is a valid AWS s3 bucket URL. 