### PR TITLE
Fix/Pubmed Telescope: Merge upserts and deletes

### DIFF
--- a/academic_observatory_workflows/workflows/tests/test_pubmed_telescope.py
+++ b/academic_observatory_workflows/workflows/tests/test_pubmed_telescope.py
@@ -509,12 +509,12 @@ class TestPubMedTelescope(ObservatoryTestCase):
                     for datafile in updatefiles:
                         self.assertTrue(os.path.exists(datafile.transform_upsert_file_path))
 
-                    ### Merge upserts and deletes  ###
+                    ### Merge upserts and deletes ###
                     task_id = workflow.merge_upserts_and_deletes.__name__
                     ti = env.run_task(task_id)
                     self.assertEqual(State.SUCCESS, ti.state)
 
-                    # Check that files have been created for each datafile.
+                    # Check that the merged upserts and deletes have been written to disk.
                     self.assertTrue(os.path.exists(release.merged_delete_file_path))
                     for datafile in updatefiles:
                         self.assertTrue(os.path.exists(datafile.merged_upsert_file_path))
@@ -770,7 +770,7 @@ class TestPubMedTelescope(ObservatoryTestCase):
                     ti = env.run_task(task_id)
                     self.assertEqual(State.SUCCESS, ti.state)
 
-                    # Check that files have been created for each datafile.
+                    # Check that the merged upserts and deletes have been written to disk.
                     self.assertTrue(os.path.exists(release.merged_delete_file_path))
                     for datafile in updatefiles:
                         self.assertTrue(os.path.exists(datafile.merged_upsert_file_path))
@@ -1131,7 +1131,7 @@ class TestPubMedUtils(ObservatoryTestCase):
             self.assertEqual(data_to_write, data_read_in)
 
     def test_save_pubmed_merged_upserts(self):
-        """Test if records can be reliably pulled from transformed files and written to merged record files."""
+        """Test if records can be reliably pulled from transformed files and written to file."""
 
         filename = "pubmed_temp.jsonl"
         upsert_index = {PMID(12345, 1): filename}
@@ -1152,7 +1152,10 @@ class TestPubMedUtils(ObservatoryTestCase):
 
             upsert_output_path = os.path.join(tmp_dir, "upsert_output.jsonl.gz")
 
-            save_pubmed_merged_upserts(filename, upsert_index, input_path, upsert_output_path)
+            result_path = save_pubmed_merged_upserts(filename, upsert_index, input_path, upsert_output_path)
+
+            # Ensure that merged records have been written to disk.
+            self.assertTrue(os.path.exists(result_path))
 
             with gzip.open(upsert_output_path, "rb") as f_in:
                 data = [json.loads(line) for line in f_in]


### PR DESCRIPTION
A proposed fix for the multiprocessing step in the Pubmed telescope for writing out the merged upserts and deletes. 
The function `save_merged_upserts_and_deletes` now returns the path to the file that it writes to. The task will now only log the path if the spawned process in the process pool has completed, using `future.result()`. 

Also added logging to the `merge_upserts_and_deletes` function so that we know it is processing each updatefile properly.