### PR TITLE
added code of conduct file, and contributing guide that links to the …

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+The [Curtin Open Knowledge Initiative (COKI)](https://openknowledge.community/) is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity. By participating in the activities of the COKI community, participants accept to abide by [The COKI Code of Conduct](https://openknowledge.community/about-coki/code-of-conduct/) and accept the procedures by which any Code of Conduct incidents are resolved.
+
+Please refer to [The COKI Code of Conduct on our website](https://openknowledge.community/about-coki/code-of-conduct/) for further details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+The [academic-observatory-workflows](https://github.com/The-Academic-Observatory/academic-observatory-workflows) is a dependent repository of the [observatory-platform](https://github.com/The-Academic-Observatory/observatory-platform).
+
+We welcome contributions to the project, please see the [CONTRIBUTING.md file for the Observatory Platform](https://github.com/The-Academic-Observatory/observatory-platform//blob/develop/CONTRIBUTING.md) for details about how to contribute to this repository.


### PR DESCRIPTION
Added CODE_OF_CONDUCT.md and CONTRIBUTING.md. Links to CONTRIBUTING.md on the observatory platform repo develop branch should redirect if develop is renamed to main. 