### PR TITLE
Add more countries and institutions to OA Dashboard

### DIFF
--- a/academic_observatory_workflows/workflows/oa_dashboard_workflow/oa_dashboard_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_dashboard_workflow/oa_dashboard_workflow.py
@@ -920,10 +920,11 @@ def make_entity_stats(entities: List[Dict]) -> EntityStats:
     data, bins = np.histogram(p_outputs_open, bins="auto")
     hist_p_outputs_open = Histogram(data.tolist(), bins.tolist())
 
-    data, bins = np.histogram(np.log10(n_outputs[n_outputs != 0]), bins="auto")
+    # Make log10 shifted histograms. Add 1 to values to make consistent with UI
+    data, bins = np.histogram(np.log10(n_outputs + 1), bins="auto")
     hist_n_outputs = Histogram(data.tolist(), bins.tolist())
 
-    data, bins = np.histogram(np.log10(n_outputs_open[n_outputs_open != 0]), bins="auto")
+    data, bins = np.histogram(np.log10(n_outputs_open + 1), bins="auto")
     hist_n_outputs_open = Histogram(data.tolist(), bins.tolist())
 
     return EntityStats(

--- a/academic_observatory_workflows/workflows/oa_dashboard_workflow/oa_dashboard_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_dashboard_workflow/oa_dashboard_workflow.py
@@ -71,7 +71,7 @@ from observatory.platform.workflows.workflow import Workflow, make_snapshot_date
 from observatory.platform.workflows.workflow import cleanup
 
 WORKFLOW_MODULE = "oa_dashboard_workflow"
-INCLUSION_THRESHOLD = {"country": 15, "institution": 1000}
+INCLUSION_THRESHOLD = {"country": 5, "institution": 50}
 MAX_REPOSITORIES = 200
 START_YEAR = 2000
 END_YEAR = pendulum.now().year - 1

--- a/academic_observatory_workflows/workflows/oa_dashboard_workflow/sql/country.sql.jinja2
+++ b/academic_observatory_workflows/workflows/oa_dashboard_workflow/sql/country.sql.jinja2
@@ -12,7 +12,7 @@ SELECT
   FORMAT("logos/country/sm/%s.svg", country.alpha3) as logo_sm,
   FORMAT("logos/country/md/%s.svg", country.alpha3) as logo_md,
   FORMAT("logos/country/md/%s.svg", country.alpha3) as logo_lg,
-  country.wikipedia_url,
+  REGEXP_REPLACE(country.wikipedia_url, r'^http://', 'https://') AS wikipedia_url,
   country.region as region,
   country.subregion as subregion,
   (SELECT MIN(year_struct.year) FROM UNNEST(years_agg.years) as year_struct) as start_year,

--- a/academic_observatory_workflows/workflows/oa_dashboard_workflow/sql/institution.sql.jinja2
+++ b/academic_observatory_workflows/workflows/oa_dashboard_workflow/sql/institution.sql.jinja2
@@ -13,7 +13,7 @@ SELECT
   CAST(NULL AS STRING) as logo_md,
   CAST(NULL AS STRING) as logo_lg,
   (SELECT * from ror.links LIMIT 1) AS url,
-  ror.wikipedia_url,
+  REGEXP_REPLACE(ror.wikipedia_url, r'^http://', 'https://') AS wikipedia_url,
   country.region as region,
   country.subregion as subregion,
   country.alpha3 as country_code,

--- a/academic_observatory_workflows/workflows/oa_dashboard_workflow/tests/test_oa_dashboard_workflow.py
+++ b/academic_observatory_workflows/workflows/oa_dashboard_workflow/tests/test_oa_dashboard_workflow.py
@@ -144,8 +144,12 @@ class TestFunctions(TestCase):
             median=dict(p_outputs_open=50),
             histograms=EntityHistograms(
                 p_outputs_open=Histogram(data=[2, 0, 1], bins=[30.0, 53.33333333333333, 76.66666666666666, 100.0]),
-                n_outputs=Histogram(data=[1, 1, 1], bins=[1.0, 1.6666666666666665, 2.333333333333333, 3.0]),
-                n_outputs_open=Histogram(data=[1, 1, 1], bins=[1.0, 1.6666666666666665, 2.333333333333333, 3.0]),
+                n_outputs=Histogram(
+                    data=[1, 1, 1], bins=[1.041392685158225, 1.6944064825985894, 2.3474202800389543, 3.000434077479319]
+                ),
+                n_outputs_open=Histogram(
+                    data=[1, 1, 1], bins=[1.041392685158225, 1.6944064825985894, 2.3474202800389543, 3.000434077479319]
+                ),
             ),
         )
         self.assertEqual(expected_stats, stats)


### PR DESCRIPTION
Add more countries and institutions to OA Dashboard:
* Lower thresholds for including entities.
* Fix issue when fetching Wikipedia descriptions caused by duplicate Wikipedia pages, by replacing http:// with https:// for Wikipedia URLs.
* Shift data for histograms in the same way as UI.