### PR TITLE
Fix/OpenAlex: Account for new top level field when merging generated schemas

### DIFF
--- a/academic_observatory_workflows/fixtures/openalex/schema_generator/expected.json
+++ b/academic_observatory_workflows/fixtures/openalex/schema_generator/expected.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1588104399da4e03b11370bd5c51f33fddabf609ec1e5d60cbf18ac484219908
-size 812
+oid sha256:bfbd71779f324ba26a6dba9cc308c1c9cc2488de6417ad9e7825dca03dcad535
+size 876

--- a/academic_observatory_workflows/fixtures/openalex/schema_generator/part_001.jsonl
+++ b/academic_observatory_workflows/fixtures/openalex/schema_generator/part_001.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:255e12d2767ef10561db42acfe13935900f91c4bee2d9b0a9c41187c66c2c8d5
-size 629
+oid sha256:ef9c96aa809989a6c3d2ec4cbf7b69cd65278d45d16749f28d91adcb78ad1e28
+size 678

--- a/academic_observatory_workflows/workflows/openalex_telescope.py
+++ b/academic_observatory_workflows/workflows/openalex_telescope.py
@@ -1295,8 +1295,14 @@ def merge_schema_maps(to_add: OrderedDict, old: OrderedDict) -> OrderedDict:
     schema_generator = SchemaGenerator()
 
     if old:
+        # Loop through the fields to add to the schema
         for key, value in to_add.items():
-            old[key] = schema_generator.merge_schema_entry(old_schema_entry=old[key], new_schema_entry=value)
+            if key in old:
+                # Merge existing fields together.
+                old[key] = schema_generator.merge_schema_entry(old_schema_entry=old[key], new_schema_entry=value)
+            else:
+                # New top level field is added.
+                old[key] = value
     else:
         # Initialise it with first result if it is empty
         old = to_add.copy()


### PR DESCRIPTION
The merge schema function in the OpenAlex telescope only accounted for sub/nested fields in incoming the data structure. This fix accounts for new top level fields that are not present in the "old" schema and simply adds them to the merged schema object. I have also added this specific case to the unit test files. 

Please review and edit as needed.