### PR TITLE
Fix fetch wikipedia descriptions

### DIFF
--- a/academic_observatory_workflows/tests/fixtures/expected_fetch_wiki_descriptions.json
+++ b/academic_observatory_workflows/tests/fixtures/expected_fetch_wiki_descriptions.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76c5408c10b699c3170eaa79e0ee249bf792df1e6b0d65e90c3807a2c2550aba
-size 1778
+oid sha256:b54329b38b82a318854d5dc4b68e762fa846d2247b93d1b6e8953948078fdff4
+size 2564

--- a/academic_observatory_workflows/tests/fixtures/test_fetch_wiki_description.yaml
+++ b/academic_observatory_workflows/tests/fixtures/test_fetch_wiki_description.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51b3f57e81e4228b8ad7f23cb2c49ff02da5e271c9e2ec8f4288a52d4305cc57
-size 9524
+oid sha256:7e65f6c8ca97b643b2121072edd6fc6039f12a7712366cec2b7da36d19f7fa6c
+size 10737

--- a/academic_observatory_workflows/tests/test_wikipedia.py
+++ b/academic_observatory_workflows/tests/test_wikipedia.py
@@ -65,6 +65,10 @@ class TestWikipedia(TestCase):
             "https://en.wikipedia.org/wiki/Office_of_Scientific_and_Technical_Information",
             "https://en.wikipedia.org/wiki/National_Oilwell_Varco#Awards_and_Accolades",
             "https://en.wikipedia.org/wiki/%C3%85land",
+            "https://en.wikipedia.org/wiki/Universiti_Teknologi_MARA_System",
+            "https://en.wikipedia.org/wiki/Universiti_Teknologi_MARA",
+            "https://en.wikipedia.org/wiki/Kellogg%27s",
+            "https://en.wikipedia.org/wiki/Kellogg's",
         ]
         path = os.path.join(FIXTURES_FOLDER, "expected_fetch_wiki_descriptions.json")
         with open(path, "r") as f:


### PR DESCRIPTION
Fixed an issue in `fetch_wikipedia_descriptions_batch`, which was not returning descriptions for all input URLs in all cases. Specifically, when duplicate Wikipedia URLs were supplied and when two different URLs that point to the same page were supplied (e.g. one URL encoded and one not) .

Also added logging messages to print more info when there is a discrepancy between input URLs and output URLs.
