### PR TITLE
Fix a couple of bugs in Unpaywall Telescope

### DIFF
--- a/academic_observatory_workflows/unpaywall_telescope/unpaywall_telescope.py
+++ b/academic_observatory_workflows/unpaywall_telescope/unpaywall_telescope.py
@@ -160,7 +160,7 @@ class UnpaywallRelease(Release):
 
         # The first changefile is the oldest and the last one is the newest
         # the start and end date of the Unpaywall changefiles processed in this release.
-        changefiles = sorted(changefiles, key=lambda c: c.changefile_date, reverse=True)
+        changefiles = sorted(changefiles, key=lambda c: c.changefile_date, reverse=False)
         start_date = changefiles[0].changefile_date
         end_date = changefiles[-1].changefile_date
 
@@ -608,12 +608,14 @@ def create_dag(
                     "transform: find and replace the 'authenticated-orcid' string in the jsonl to 'authenticated_orcid'"
                 )
                 for changefile in release.changefiles:
-                    find_replace_file(
-                        src=changefile.extract_file_path,
-                        dst=changefile.transform_file_path,
-                        pattern="authenticated-orcid",
-                        replacement="authenticated_orcid",
-                    )
+                    with open(changefile.extract_file_path, "r") as file_in:
+                        with open(changefile.transform_file_path, "w") as file_out:
+                            for line in file_in:
+                                if line.strip() != "null":
+                                    output = re.sub(
+                                        pattern="authenticated-orcid", repl="authenticated_orcid", string=line
+                                    )
+                                    file_out.write(output)
 
                 logging.info(
                     "transform: Merge change files, make sure that we process them from the oldest changefile to the newest"


### PR DESCRIPTION
Fix a couple of errors in the Unpaywall Telecope:
* Unpaywall changefile changed_dois_with_versions_2024-06-10T080001.jsonl at row 82563 is just null instead of a valid JSON object.
* Changfile sorting was in the release object was incorrect.