### PR TITLE
Fix OA Dashboard divide by zero null error

### DIFF
--- a/academic_observatory_workflows/oa_dashboard_workflow/sql/data.sql.jinja2
+++ b/academic_observatory_workflows/oa_dashboard_workflow/sql/data.sql.jinja2
@@ -1,7 +1,7 @@
 CREATE TEMP FUNCTION calcPercent(numerator FLOAT64, denominator FLOAT64)
 RETURNS FLOAT64
 AS (
-  SAFE_DIVIDE(numerator * 100 , denominator)
+  IFNULL(SAFE_DIVIDE(numerator * 100 , denominator), 0)
 );
 
 CREATE TEMP FUNCTION removeRorPrefix(str STRING)


### PR DESCRIPTION
Return 0 for percentage rather than NULL when divide by zero error occurs.