### PR TITLE
Add field 'affiliations' to OpenAlex ingest

### DIFF
--- a/academic_observatory_workflows/openalex_telescope/schema/works.json
+++ b/academic_observatory_workflows/openalex_telescope/schema/works.json
@@ -199,6 +199,24 @@
         "mode": "REPEATED"
       },
       {
+        "name": "affiliations",
+        "type": "RECORD",
+        "mode": "REPEATED",
+        "description": "Each institutional affiliation that this author has claimed will be listed here: the raw affiliation string that we found, along with the OpenAlex Institution ID or IDs that we matched it to.",
+        "fields": [
+          {
+            "name": "raw_affiliation_string",
+            "type": "STRING",
+            "mode": "NULLABLE"
+          },
+          {
+            "name": "institution_ids",
+            "type": "STRING",
+            "mode": "REPEATED"
+          }
+        ]
+      },
+      {
         "name": "raw_author_name",
         "type": "STRING",
         "mode": "NULLABLE",


### PR DESCRIPTION
Add newly added field 'affiliations' which is useful for examining affiliation mapping. Link to field description in technical documentation: https://docs.openalex.org/api-entities/works/work-object/authorship-object#affiliations

cc @cameronneylon