### PR TITLE
unpaywall api updates

### DIFF
--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/fixtures/get_snapshot_file_name_missing_location.yaml
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/fixtures/get_snapshot_file_name_missing_location.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:976ce11aea68d89ec5c2df936193f2d42f3fb032bba64e51311f14c8620986cb
+size 1534

--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/fixtures/get_snapshot_file_name_success.yaml
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/fixtures/get_snapshot_file_name_success.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8843c6c9b0899b559590a9fd9fc4267c00b523477c6be2ada7c7adf82a5a5576
-size 936
+oid sha256:1fb5a4c647049bb268a5513f0768bf997dbaf301edf98b29d028a2e1a3561dd1
+size 1741

--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_tasks.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_tasks.py
@@ -144,12 +144,19 @@ class TestUnpaywallUtils(SandboxTestCase):
             filter_query_parameters=["api_key"],
         ):
             filename = get_snapshot_file_name(UNPAYWALL_BASE_URL, os.getenv("UNPAYWALL_API_KEY", "my-api-key"))
-            self.assertEqual("unpaywall_snapshot_2023-04-25T083002.jsonl.gz", filename)
+            self.assertEqual("unpaywall_snapshot_2025-07-02T154512.jsonl.gz", filename)
+
+        with vcr.use_cassette(
+            os.path.join(FIXTURES_FOLDER, "get_snapshot_file_name_missing_location.yaml"),
+            filter_query_parameters=["api_key"],
+        ):
+            with self.assertRaisesRegex(AirflowException, 'Missing "location"'):
+                get_snapshot_file_name(UNPAYWALL_BASE_URL, os.getenv("UNPAYWALL_API_KEY", "my-api-key"))
 
         # An invalid API key
         with vcr.use_cassette(
             os.path.join(FIXTURES_FOLDER, "get_snapshot_file_name_failure.yaml"),
             filter_query_parameters=["api_key"],
         ):
-            with self.assertRaises(AirflowException):
+            with self.assertRaisesRegex(AirflowException, "Unexpected status code"):
                 get_snapshot_file_name(UNPAYWALL_BASE_URL, "invalid-api-key")

--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_tasks.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_tasks.py
@@ -144,7 +144,7 @@ class TestUnpaywallUtils(SandboxTestCase):
             filter_query_parameters=["api_key"],
         ):
             filename = get_snapshot_file_name(UNPAYWALL_BASE_URL, os.getenv("UNPAYWALL_API_KEY", "my-api-key"))
-            self.assertEqual("unpaywall_snapshot_2025-07-02T154512.jsonl.gz", filename)
+            self.assertEqual("unpaywall_snapshot_2023-04-25T083002.jsonl.gz", filename)
 
         with vcr.use_cassette(
             os.path.join(FIXTURES_FOLDER, "get_snapshot_file_name_missing_location.yaml"),

--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_telescope.py
@@ -166,7 +166,7 @@ class TestUnpaywallTelescope(SandboxTestCase):
             upsert_airflow_connection(conn_id="unpaywall", conn_type="http", password="secret")
             upsert_airflow_connection(**TestConfig.gke_cluster_connection)
             with patch("academic_observatory_workflows.unpaywall_telescope.tasks.get_http_response_json") as cfs, patch(
-                "academic_observatory_workflows.unpaywall_telescope.tasks.get_filename_from_http_header"
+                "academic_observatory_workflows.unpaywall_telescope.tasks.get_snapshot_file_name"
             ) as ss:
                 cfs.return_value = {
                     "list": [{"filename": "changed_dois_with_versions_2023-04-25T080001.jsonl.gz", "filetype": "jsonl"}]
@@ -192,7 +192,7 @@ class TestUnpaywallTelescope(SandboxTestCase):
             data_interval_start = pendulum.datetime(2023, 4, 26)
             data_interval_end = data_interval_start.end_of("day")
             with patch("academic_observatory_workflows.unpaywall_telescope.tasks.get_http_response_json") as cfs, patch(
-                "academic_observatory_workflows.unpaywall_telescope.tasks.get_filename_from_http_header"
+                "academic_observatory_workflows.unpaywall_telescope.tasks.get_snapshot_file_name"
             ) as ss:
                 cfs.return_value = {"list": []}
                 ss.return_value = "filename"
@@ -210,7 +210,7 @@ class TestUnpaywallTelescope(SandboxTestCase):
             data_interval_start = pendulum.datetime(2023, 4, 27)
             data_interval_end = data_interval_start.end_of("day")
             with patch("academic_observatory_workflows.unpaywall_telescope.tasks.get_http_response_json") as cfs, patch(
-                "academic_observatory_workflows.unpaywall_telescope.tasks.get_filename_from_http_header"
+                "academic_observatory_workflows.unpaywall_telescope.tasks.get_snapshot_file_name"
             ) as ss:
                 cfs.return_value = {
                     "list": [


### PR DESCRIPTION
Unpaywall's snapshot endpoint has changed along with its header information. We used to rely on the header information for the filename. This PR updates the filename extraction to work with the new endpoint.