### PR TITLE
Pubmed unstring nulls

### DIFF
--- a/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tasks.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tasks.py
@@ -982,7 +982,7 @@ def transform_pubmed(input_path: str, upsert_path: str) -> Union[bool, str, Pubm
 
                 try:
                     context = etree.iterparse(file, events=("end",), tag=("PubmedArticle", "DeleteCitation"))
-                    for event, elem in context:
+                    for _, elem in context:
                         try:
                             record = parse_pubmed_element(elem, validate=False, ignore_errors=True)
                         except Exception as e:
@@ -1129,6 +1129,8 @@ def add_attributes(obj: Union[StringElement, DictionaryElement, ListElement, Ord
                 new[key] = add_attributes(obj.attributes[key])
         else:
             new = str(obj)
+            if new == "null":  # We want null values to be Nones so they're not interpreted as strings by BigQuery
+                new = None
 
         return new
 
@@ -1187,7 +1189,7 @@ bad_list_fields = {
 
 
 def change_pubmed_list_structure(
-    obj: Union[dict, list, str, DictionaryElement, ListElement, StringElement]
+    obj: Union[dict, list, str, DictionaryElement, ListElement, StringElement],
 ) -> Union[dict, list, str, DictionaryElement, ListElement, StringElement]:
     """Recursively travel down the Pubmed data tree to move the specified fields
     up one level to make it easier to query in Bigquery.

--- a/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tests/fixtures/updatefiles/pubmed22n0003.xml.gz
+++ b/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tests/fixtures/updatefiles/pubmed22n0003.xml.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:793244f21a5084e3af3c01b827123c9a9768185e2ff72fa2ca5a0ab0baa6cd23
-size 2280
+oid sha256:e455abe14b2cec77bb597a05eb0df6de341e5bad5a6d93794f755ae38676d683
+size 2285

--- a/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tests/fixtures/updatefiles/pubmed22n0003.xml.gz.md5
+++ b/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tests/fixtures/updatefiles/pubmed22n0003.xml.gz.md5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e4e5a5f2bf514f3c582fb071d84c3054ee8cf245850539a5f3f90b135c6ee6b
-size 59
+oid sha256:f669d5d9068f9280c383b91c744cdabba249207262112918c7aa97e4fcf732a9
+size 60


### PR DESCRIPTION
Pubmed has some nulls in its data. Which is fine, but our transform step turns the nulls into "null", which is an issue. This pr converts them to python Nones, which are then covnerted to json nulls before the bigquery upload