### PR TITLE
Add URL to entity data

### DIFF
--- a/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/tasks.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/tasks.py
@@ -539,6 +539,7 @@ def oa_dashboard_subset(item: Dict) -> Dict:
         "id": "id",
         "name": "name",
         "logo_sm": "logo_sm",
+        "url": Coalesce("url", default=SKIP),
         "entity_type": "entity_type",
         "region": "region",
         "subregion": "subregion",
@@ -559,7 +560,10 @@ def oa_dashboard_subset(item: Dict) -> Dict:
         },
     }
 
-    return glom(item, subset_spec)
+    subset = glom(item, subset_spec)
+    if subset.get("url"):
+        subset["url"] = urlparse(subset["url"]).netloc  # Strip url to domain only
+    return subset
 
 
 def zenodo_subset(item: Dict):


### PR DESCRIPTION
The OA dashboard needs access to the domain names of the institutions at runtime. This is the easiest way to supply it.