### PR TITLE
remove previous dag run sensor

### DIFF
--- a/academic-observatory-workflows/academic_observatory_workflows/crossref_fundref_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/crossref_fundref_telescope/telescope.py
@@ -109,6 +109,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def crossref_fundref():

--- a/academic-observatory-workflows/academic_observatory_workflows/crossref_metadata_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/crossref_metadata_telescope/telescope.py
@@ -131,6 +131,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def crossref_metadata():

--- a/academic-observatory-workflows/academic_observatory_workflows/doi_workflow/workflow.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/doi_workflow/workflow.py
@@ -204,6 +204,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def doi():

--- a/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/workflow.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/workflow.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import List, Optional
 
 from airflow import DAG
@@ -174,6 +173,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def oa_dashboard_workflow():

--- a/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/telescope.py
@@ -566,8 +566,6 @@ def create_dag(dag_params: DagParams) -> DAG:
             workflow_folder = make_workflow_folder(dag_params.dag_id, context["run_id"])
             cleanup(dag_id=dag_params.dag_id, workflow_folder=workflow_folder)
 
-        external_task_id = "dag_run_complete"
-
         task_check_dependencies = check_dependencies(
             airflow_conns=[dag_params.gke_conn_id, dag_params.aws_conn_id, dag_params.slack_conn_id]
         )
@@ -594,7 +592,6 @@ def create_dag(dag_params: DagParams) -> DAG:
 
         task_add_dataset_release = add_dataset_release(xcom_entity_index, dag_params)
         task_cleanup_workflow = cleanup_workflow(dag_params)
-        task_dag_run_complete = EmptyOperator(task_id=external_task_id)
 
         (
             task_check_dependencies
@@ -604,7 +601,6 @@ def create_dag(dag_params: DagParams) -> DAG:
             >> process_entities
             >> task_add_dataset_release
             >> task_cleanup_workflow
-            >> task_dag_run_complete
         )
 
     return openalex()

--- a/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/telescope.py
@@ -16,8 +16,6 @@
 # Author: Aniek Roelofs, James Diprose, Alex Massen-Hane
 
 from __future__ import annotations
-from datetime import datetime
-from dateutil import relativedelta
 import logging
 from typing import List, Optional
 
@@ -31,16 +29,11 @@ from academic_observatory_workflows.config import project_path
 from academic_observatory_workflows.openalex_telescope.release import OpenAlexEntity
 from observatory_platform.airflow.airflow import is_first_dag_run, on_failure_callback
 from observatory_platform.airflow.release import release_to_bucket
-from observatory_platform.airflow.sensors import PreviousDagRunSensor
 from observatory_platform.airflow.tasks import check_dependencies, gke_create_storage, gke_delete_storage
 from observatory_platform.airflow.workflow import cleanup, CloudWorkspace, make_workflow_folder
 from observatory_platform.config import AirflowConns
 from observatory_platform.google.bigquery import bq_create_dataset
 from observatory_platform.google.gke import DEFAULT_GKE_IMAGE, GkeParams
-
-
-def previous_month_fn(execution_date: datetime.datetime) -> datetime.datetime:
-    return execution_date - relativedelta(months=1)
 
 
 class DagParams:
@@ -319,6 +312,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def openalex():
@@ -573,9 +567,6 @@ def create_dag(dag_params: DagParams) -> DAG:
             cleanup(dag_id=dag_params.dag_id, workflow_folder=workflow_folder)
 
         external_task_id = "dag_run_complete"
-        sensor = PreviousDagRunSensor(
-            dag_id=dag_params.dag_id, external_task_id=external_task_id, execution_date_fn=previous_month_fn
-        )
 
         task_check_dependencies = check_dependencies(
             airflow_conns=[dag_params.gke_conn_id, dag_params.aws_conn_id, dag_params.slack_conn_id]
@@ -606,8 +597,7 @@ def create_dag(dag_params: DagParams) -> DAG:
         task_dag_run_complete = EmptyOperator(task_id=external_task_id)
 
         (
-            sensor
-            >> task_check_dependencies
+            task_check_dependencies
             >> xcom_entity_index
             >> task_short_circuit
             >> task_create_dataset

--- a/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/tests/test_telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/tests/test_telescope.py
@@ -85,7 +85,6 @@ class TestOpenAlexTelescope(SandboxTestCase):
             "expire_previous_version",
         ]
         expected = {
-            "wait_for_prev_dag_run": ["check_dependencies"],
             "check_dependencies": ["fetch_entities"],
             "fetch_entities": [
                 "short_circuit",
@@ -217,8 +216,7 @@ class TestOpenAlexTelescope(SandboxTestCase):
             "topics.gke_delete_storage": ["add_dataset_release"],
             # Cleanup
             "add_dataset_release": ["cleanup_workflow"],
-            "cleanup_workflow": ["dag_run_complete"],
-            "dag_run_complete": [],
+            "cleanup_workflow": [],
         }
         self.assert_dag_structure(expected, dag)
 
@@ -321,7 +319,6 @@ class TestOpenAlexTelescope(SandboxTestCase):
                 gke_namespace=TestConfig.gke_namespace,
                 gke_resource_map=resource_map,
                 gke_volume_map=gke_volume_map,
-                test_run=True,
                 retries=0,
             )
             dag = create_dag(dag_params)

--- a/academic-observatory-workflows/academic_observatory_workflows/orcid_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/orcid_telescope/telescope.py
@@ -23,13 +23,11 @@ from typing import Optional
 import pendulum
 from airflow import DAG
 from airflow.decorators import dag, task
-from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 from academic_observatory_workflows.config import project_path
 from academic_observatory_workflows.orcid_telescope import tasks
 from observatory_platform.airflow.airflow import on_failure_callback
-from observatory_platform.airflow.sensors import PreviousDagRunSensor
 from observatory_platform.airflow.tasks import check_dependencies, gke_create_storage, gke_delete_storage
 from observatory_platform.airflow.workflow import CloudWorkspace
 from observatory_platform.config import AirflowConns
@@ -93,7 +91,6 @@ class DagParams:
         schedule: str = "0 0 * * 0",  # Midnight UTC every Sunday
         max_active_runs: int = 1,
         retries: int = 3,
-        test_run: bool = False,
         gke_volume_size: str = "1000Gi",  # Only required for full download, ~550 Gi for uncompressed files and then less for compressed transformed files.
         gke_namespace: str = "coki-astro",
         gke_volume_name: str = "orcid",
@@ -121,7 +118,6 @@ class DagParams:
         self.schedule = schedule
         self.max_active_runs = max_active_runs
         self.retries = retries
-        self.test_run = test_run
         self.gke_params = GkeParams(
             gke_volume_size=gke_volume_size, gke_namespace=gke_namespace, gke_volume_name=gke_volume_name, **kwargs
         )
@@ -143,6 +139,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def orcid():
@@ -310,13 +307,6 @@ def create_dag(dag_params: DagParams) -> DAG:
 
             tasks.cleanup_workflow(release)
 
-        external_task_id = "dag_run_complete"
-        if dag_params.test_run:
-            sensor = EmptyOperator(task_id="wait_for_prev_dag_run")
-        else:
-            sensor = PreviousDagRunSensor(
-                dag_id=dag_params.dag_id, external_task_id=external_task_id, execution_date_fn=previous_month_fn
-            )
         task_check_dependencies = check_dependencies(airflow_conns=[dag_params.aws_orcid_conn_id])
         xcom_release = fetch_release()
         task_create_dataset = create_dataset(xcom_release, dag_params)
@@ -343,11 +333,9 @@ def create_dag(dag_params: DagParams) -> DAG:
         task_bq_delete_records = bq_delete_records(xcom_release)
         task_add_dataset_release = add_dataset_release(xcom_release, xcom_latest_modified_date, dag_params)
         task_cleanup_workflow = cleanup_workflow(xcom_release)
-        task_dag_run_complete = EmptyOperator(task_id=external_task_id)
 
         (
-            sensor
-            >> task_check_dependencies
+            task_check_dependencies
             >> xcom_release
             >> task_create_dataset
             >> task_transfer_orcid
@@ -366,7 +354,6 @@ def create_dag(dag_params: DagParams) -> DAG:
             >> task_bq_delete_records
             >> task_add_dataset_release
             >> task_cleanup_workflow
-            >> task_dag_run_complete
         )
 
     return orcid()

--- a/academic-observatory-workflows/academic_observatory_workflows/orcid_telescope/tests/test_telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/orcid_telescope/tests/test_telescope.py
@@ -114,7 +114,6 @@ class TestOrcidTelescope(SandboxTestCase):
         dag = create_dag(DagParams(dag_id=self.dag_id, cloud_workspace=self.fake_cloud_workspace))
         self.assert_dag_structure(
             {
-                "wait_for_prev_dag_run": ["check_dependencies"],
                 "check_dependencies": ["fetch_release"],
                 "fetch_release": [
                     "create_dataset",
@@ -149,8 +148,7 @@ class TestOrcidTelescope(SandboxTestCase):
                 "bq_upsert_records": ["bq_delete_records"],
                 "bq_delete_records": ["add_dataset_release"],
                 "add_dataset_release": ["cleanup_workflow"],
-                "cleanup_workflow": ["dag_run_complete"],
-                "dag_run_complete": [],
+                "cleanup_workflow": [],
             },
             dag,
         )
@@ -207,7 +205,6 @@ class TestOrcidTelescope(SandboxTestCase):
                 gke_namespace=TestConfig.gke_namespace,
                 gke_volume_size="500Mi",
                 gke_resource_overrides=task_resources,
-                test_run=True,
             )
             api = DatasetAPI(bq_project_id=env.cloud_workspace.project_id, bq_dataset_id=test_params.api_bq_dataset_id)
 

--- a/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/telescope.py
@@ -26,7 +26,6 @@ from airflow.operators.empty import EmptyOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 from observatory_platform.airflow.airflow import on_failure_callback
-from observatory_platform.airflow.sensors import PreviousDagRunSensor
 from observatory_platform.airflow.tasks import check_dependencies, gke_create_storage, gke_delete_storage
 from observatory_platform.airflow.workflow import CloudWorkspace
 from observatory_platform.google.gke import gke_make_container_resources, gke_make_kubernetes_task_params, GkeParams
@@ -135,6 +134,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def pubmed():
@@ -510,13 +510,6 @@ def create_dag(dag_params: DagParams) -> DAG:
             release = release_from_bucket(dag_params.cloud_workspace.download_bucket, release_id)
             tasks.cleanup_workflow(release)
 
-        external_task_id = "dag_run_complete"
-        if dag_params.test_run:
-            sensor = EmptyOperator(task_id="wait_for_prev_dag_run")
-        else:
-            sensor = PreviousDagRunSensor(
-                dag_id=dag_params.dag_id, external_task_id=external_task_id, execution_date_fn=previous_month_fn
-            )
         task_check_dependencies = check_dependencies()
         xcom_release_id = fetch_release()
         task_shortcircuit = short_circuit(xcom_release_id, dag_params)
@@ -536,13 +529,11 @@ def create_dag(dag_params: DagParams) -> DAG:
         )
         task_add_dataset_releases = add_dataset_releases(xcom_release_id, dag_params)
         task_cleanup_workflow = cleanup_workflow(xcom_release_id, dag_params)
-        task_dag_run_complete = EmptyOperator(task_id=external_task_id)
         task_merge_branches = EmptyOperator(task_id="merge_branches")
 
         # Define DAG structure
         (
-            sensor
-            >> task_check_dependencies
+            task_check_dependencies
             >> xcom_release_id
             >> task_shortcircuit
             >> task_create_snapshot
@@ -555,12 +546,6 @@ def create_dag(dag_params: DagParams) -> DAG:
         task_group_updatefiles >> task_merge_branches
 
         # Final steps of the DAG
-        (
-            task_merge_branches
-            >> task_delete_storage
-            >> task_add_dataset_releases
-            >> task_cleanup_workflow
-            >> task_dag_run_complete
-        )
+        (task_merge_branches >> task_delete_storage >> task_add_dataset_releases >> task_cleanup_workflow)
 
     return pubmed()

--- a/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tests/test_telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/pubmed_telescope/tests/test_telescope.py
@@ -161,7 +161,6 @@ class TestPubMedTelescope(SandboxTestCase):
 
         self.assert_dag_structure(
             {
-                "wait_for_prev_dag_run": ["check_dependencies"],
                 "check_dependencies": ["fetch_release"],
                 "fetch_release": [
                     "short_circuit",
@@ -203,8 +202,7 @@ class TestPubMedTelescope(SandboxTestCase):
                 "merge_branches": ["gke_delete_storage"],
                 "gke_delete_storage": ["add_dataset_releases"],
                 "add_dataset_releases": ["cleanup_workflow"],
-                "cleanup_workflow": ["dag_run_complete"],
-                "dag_run_complete": [],
+                "cleanup_workflow": [],
             },
             dag,
         )

--- a/academic-observatory-workflows/academic_observatory_workflows/ror_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/ror_telescope/telescope.py
@@ -96,6 +96,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def ror():

--- a/academic-observatory-workflows/academic_observatory_workflows/scopus_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/scopus_telescope/telescope.py
@@ -99,6 +99,7 @@ def create_dag(dag_params: DagParams):
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def scopus():

--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/telescope.py
@@ -32,15 +32,10 @@ from academic_observatory_workflows.unpaywall_telescope.release import Unpaywall
 from observatory_platform.airflow.airflow import on_failure_callback
 from observatory_platform.google.bigquery import bq_create_dataset, bq_find_schema
 from observatory_platform.airflow.release import release_from_bucket
-from observatory_platform.airflow.sensors import PreviousDagRunSensor
 from observatory_platform.airflow.tasks import check_dependencies, gke_create_storage, gke_delete_storage
 from observatory_platform.airflow.workflow import CloudWorkspace
 from observatory_platform.url_utils import get_observatory_http_header
 from observatory_platform.google.gke import GkeParams, gke_make_kubernetes_task_params, gke_make_container_resources
-
-
-def previous_month_fn(execution_date: datetime.datetime) -> datetime.datetime:
-    return execution_date - relativedelta(months=1)
 
 
 class DagParams:
@@ -88,7 +83,6 @@ class DagParams:
         schedule: str = "@daily",
         max_active_runs: int = 1,
         retries: int = 3,
-        test_run: bool = False,
         gke_volume_size: str = "1000Gi",
         gke_namespace: str = "coki-astro",
         gke_volume_name: str = "unpaywall",
@@ -116,7 +110,6 @@ class DagParams:
         self.schedule = schedule
         self.max_active_runs = max_active_runs
         self.retries = retries
-        self.test_run = test_run
         self.gke_volume_size = gke_volume_size
         self.gke_namespace = gke_namespace
         self.gke_volume_name = gke_volume_name
@@ -142,6 +135,7 @@ def create_dag(dag_params: DagParams) -> DAG:
             "owner": "airflow",
             "on_failure_callback": on_failure_callback,
             "retries": dag_params.retries,
+            "depends_on_past": True,
         },
     )
     def unpaywall():
@@ -445,15 +439,6 @@ def create_dag(dag_params: DagParams) -> DAG:
 
             tasks.cleanup_workflow(release_id, cloud_workspace=dag_params.cloud_workspace)
 
-        # Wait for the previous DAG run to finish to make sure that
-        # changefiles are processed in the correct order
-        external_task_id = "dag_run_complete"
-        if dag_params.test_run:
-            sensor = EmptyOperator(task_id="wait_for_prev_dag_run")
-        else:
-            sensor = PreviousDagRunSensor(
-                dag_id=dag_params.dag_id, external_task_id=external_task_id, execution_date_fn=previous_month_fn
-            )
         task_check_dependencies = check_dependencies(airflow_conns=[dag_params.unpaywall_conn_id])
         xcom_release_id = fetch_release()
         task_short_circuit = short_circuit(xcom_release_id)
@@ -465,7 +450,6 @@ def create_dag(dag_params: DagParams) -> DAG:
         task_add_dataset_release = add_dataset_release(xcom_release_id, dag_params)
         task_cleanup_workflow = cleanup_workflow(xcom_release_id, dag_params)
         # The last task that the next DAG run's ExternalTaskSensor waits for.
-        task_dag_run_complete = EmptyOperator(task_id=external_task_id)
         task_create_storage = gke_create_storage(
             volume_name=dag_params.gke_params.gke_volume_name,
             volume_size=dag_params.gke_params.gke_volume_size,
@@ -478,8 +462,7 @@ def create_dag(dag_params: DagParams) -> DAG:
         task_merge_branches = EmptyOperator(task_id="merge_branches")
 
         (
-            sensor
-            >> task_check_dependencies
+            task_check_dependencies
             >> xcom_release_id
             >> task_short_circuit
             >> task_create_dataset
@@ -492,12 +475,6 @@ def create_dag(dag_params: DagParams) -> DAG:
         task_group_load_snapshot >> task_group_load_changefiles
         task_group_load_changefiles >> task_merge_branches
 
-        (
-            task_merge_branches
-            >> task_delete_storage
-            >> task_add_dataset_release
-            >> task_cleanup_workflow
-            >> task_dag_run_complete
-        )
+        (task_merge_branches >> task_delete_storage >> task_add_dataset_release >> task_cleanup_workflow)
 
     return unpaywall()

--- a/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/unpaywall_telescope/tests/test_telescope.py
@@ -47,7 +47,6 @@ class TestUnpaywallTelescope(SandboxTestCase):
         dag = create_dag(DagParams(dag_id=self.dag_id, cloud_workspace=self.fake_cloud_workspace))
         self.assert_dag_structure(
             {
-                "wait_for_prev_dag_run": {"check_dependencies"},
                 "check_dependencies": {"fetch_release"},
                 "fetch_release": {
                     "load_changefiles.bq_upsert",
@@ -88,8 +87,7 @@ class TestUnpaywallTelescope(SandboxTestCase):
                 "merge_branches": {"gke_delete_storage"},
                 "gke_delete_storage": {"add_dataset_release"},
                 "add_dataset_release": {"cleanup_workflow"},
-                "cleanup_workflow": {"dag_run_complete"},
-                "dag_run_complete": {},
+                "cleanup_workflow": {},
             },
             dag,
         )
@@ -149,7 +147,6 @@ class TestUnpaywallTelescope(SandboxTestCase):
                 gke_namespace=TestConfig.gke_namespace,
                 gke_resource_overrides=task_resources,
                 gke_volume_size="500Mi",
-                test_run=True,
             )
             api = DatasetAPI(bq_project_id=env.cloud_workspace.project_id, bq_dataset_id=test_params.api_bq_dataset_id)
             main_table_id = bq_table_id(


### PR DESCRIPTION
The PreviousDagRunSensor has never worked. This PR removes it in favour of the in-built 'depends_on_past' modifier for tasks. It behaves slightly differently but should give the intended effect