### PR TITLE
update to get entity from bucket for transfer task

### DIFF
--- a/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/tests/test_workflow.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/tests/test_workflow.py
@@ -56,7 +56,6 @@ academic_observatory_workflows.oa_dashboard_workflow.tasks.INCLUSION_THRESHOLD =
 }
 from academic_observatory_workflows.oa_dashboard_workflow.workflow import create_dag, DagParams
 
-
 FIXTURES_FOLDER = project_path("oa_dashboard_workflow", "tests", "fixtures")
 DOI_FIXTURES_FOLDER = project_path("doi_workflow", "tests", "fixtures")
 DOI_SCHEMA_FOLDER = project_path("doi_workflow", "schema")
@@ -64,6 +63,8 @@ ROR_SCHEMA_FOLDER = project_path("ror_telescope", "schema")
 
 
 class TestFunctions(TestCase):
+    maxDiff = None
+
     def test_clean_url(self):
         url = "https://www.auckland.ac.nz/en.html"
         expected = "www.auckland.ac.nz"

--- a/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/tests/test_workflow.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/tests/test_workflow.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Curtin University
+# Cojjright 2021 Curtin University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import json
 import os
 import tempfile
 from typing import List
-import unittest
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -488,7 +487,7 @@ class TestOaDashboardWorkflow(SandboxTestCase):
         github_token = "github-token"
         zenodo_token = "zenodo-token"
 
-        with env.create() as t:
+        with env.create():
             ##########
             # Setup and run fake DOI workflow to test sensor
             ##########
@@ -547,7 +546,7 @@ class TestOaDashboardWorkflow(SandboxTestCase):
             env.add_connection(Connection(**TestConfig.gke_cluster_connection))
 
             ##########
-            # Run DAG
+            # Setup and run fake DOI workflow to test sensor
             ##########
 
             # Run DAG

--- a/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/workflow.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/workflow.py
@@ -22,9 +22,10 @@ from airflow import DAG
 from airflow.decorators import dag, task
 from airflow.providers.cncf.kubernetes.secret import Secret
 from airflow.models.baseoperator import chain
-from airflow.sensors.external_task import ExternalTaskSensor
+from observatory_platform.airflow.sensors import DagCompleteSensor
 import pendulum
 
+from academic_observatory_workflows.oa_dashboard_workflow.release import OaDashboardRelease
 from observatory_platform.airflow.airflow import on_failure_callback, get_airflow_connection_password
 from observatory_platform.airflow.release import make_snapshot_date
 from observatory_platform.airflow.tasks import check_dependencies, gke_create_storage, gke_delete_storage
@@ -410,11 +411,13 @@ def create_dag(dag_params: DagParams) -> DAG:
         def cleanup_workflow(release: dict, dag_params, **context):
             """Cleanup old Xcoms."""
 
-            cleanup(dag_id=dag_params.dag_id)
+            release = OaDashboardRelease.from_dict(release)
+            cleanup(workflow_folder=release.workflow_folder)
 
         # Define task connections
-        task_doi_sensor = ExternalTaskSensor(
-            task_id=f"{dag_params.doi_dag_id}_sensor", external_dag_id=dag_params.doi_dag_id, mode="reschedule"
+        task_doi_sensor = DagCompleteSensor(
+            task_id=f"{dag_params.doi_dag_id}_sensor",
+            external_dag_id=dag_params.doi_dag_id,
         )
         task_check_dependencies = check_dependencies(
             airflow_conns=[dag_params.github_conn_id, dag_params.zenodo_conn_id, dag_params.gke_params.gke_conn_id]

--- a/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/workflow.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/oa_dashboard_workflow/workflow.py
@@ -22,10 +22,9 @@ from airflow import DAG
 from airflow.decorators import dag, task
 from airflow.providers.cncf.kubernetes.secret import Secret
 from airflow.models.baseoperator import chain
-from observatory_platform.airflow.sensors import DagCompleteSensor
+from airflow.sensors.external_task import ExternalTaskSensor
 import pendulum
 
-from academic_observatory_workflows.oa_dashboard_workflow.release import OaDashboardRelease
 from observatory_platform.airflow.airflow import on_failure_callback, get_airflow_connection_password
 from observatory_platform.airflow.release import make_snapshot_date
 from observatory_platform.airflow.tasks import check_dependencies, gke_create_storage, gke_delete_storage
@@ -411,13 +410,11 @@ def create_dag(dag_params: DagParams) -> DAG:
         def cleanup_workflow(release: dict, dag_params, **context):
             """Cleanup old Xcoms."""
 
-            release = OaDashboardRelease.from_dict(release)
-            cleanup(workflow_folder=release.workflow_folder)
+            cleanup(dag_id=dag_params.dag_id)
 
         # Define task connections
-        task_doi_sensor = DagCompleteSensor(
-            task_id=f"{dag_params.doi_dag_id}_sensor",
-            external_dag_id=dag_params.doi_dag_id,
+        task_doi_sensor = ExternalTaskSensor(
+            task_id=f"{dag_params.doi_dag_id}_sensor", external_dag_id=dag_params.doi_dag_id
         )
         task_check_dependencies = check_dependencies(
             airflow_conns=[dag_params.github_conn_id, dag_params.zenodo_conn_id, dag_params.gke_params.gke_conn_id]

--- a/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/telescope.py
+++ b/academic-observatory-workflows/academic_observatory_workflows/openalex_telescope/telescope.py
@@ -416,12 +416,14 @@ def create_dag(dag_params: DagParams) -> DAG:
                 ],
                 **transfer_params,
             )
-            def aws_to_gcs_transfer(entity_index: dict, entity_name: str, dag_params: DagParams, **context):
+            def aws_to_gcs_transfer(entity_index_id: dict, entity_name: str, dag_params: DagParams, **context):
                 """Transfer files from AWS bucket to Google Cloud bucket"""
 
                 import academic_observatory_workflows.openalex_telescope.tasks as tasks
+                from observatory_platform.airflow.release import release_from_bucket
                 import os
 
+                entity_index = release_from_bucket(dag_params.cloud_workspace.transform_bucket, entity_index_id)
                 entity = tasks.get_entity(entity_index, entity_name)
                 tasks.aws_to_gcs_transfer(
                     entity=entity,
@@ -564,7 +566,7 @@ def create_dag(dag_params: DagParams) -> DAG:
                 storage_class=gke_params.gke_volume_storage_class,
                 kubernetes_conn_id=gke_params.gke_conn_id,
             )
-            task_aws_to_gcs_transfer = aws_to_gcs_transfer(entity_index, entity_name, dag_params)
+            task_aws_to_gcs_transfer = aws_to_gcs_transfer(entity_index_id, entity_name, dag_params)
             task_download = download(entity_index_id, entity_name, dag_params)
             task_transform = transform(entity_index_id, entity_name, dag_params)
             task_upload_schema = upload_schema(entity_index_id, entity_name, dag_params)


### PR DESCRIPTION
Updates the aws transfer task to use the entity_index_id and get the entity information form gcs bucket instead of passing the data as an argument